### PR TITLE
Fix the PHAR building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ e2e: bin/box.phar
 
 	php -d phar.readonly=0 box.phar build
 
-	rm box.phar bin/box.phar
+	rm box.phar
 
 
 ##

--- a/bin/box
+++ b/bin/box
@@ -24,7 +24,7 @@ use function KevinGH\Box\register_aliases;
  */
 define('BOX_PATH', dirname(__DIR__));
 
-if (extension_loaded('phar') && ($uri = Phar::running())) {
+if ($uri = Phar::running()) {
     require "$uri/vendor/autoload.php";
 } elseif (class_exists('Extract')) {
     require __DIR__.'/../vendor/autoload.php';

--- a/src/Application.php
+++ b/src/Application.php
@@ -110,11 +110,8 @@ ASCII;
     {
         $commands = parent::getDefaultCommands();
 
-        if (extension_loaded('phar')) {
-            $commands[] = new Command\Build();
-            $commands[] = new Command\Info();
-        }
-
+        $commands[] = new Command\Build();
+        $commands[] = new Command\Info();
         $commands[] = new Command\Validate();
         $commands[] = new Command\Verify();
 

--- a/src/Box_Extract.php
+++ b/src/Box_Extract.php
@@ -106,8 +106,7 @@ final class Box_Extract
     public static function findStubLength(
         string $file,
         string $pattern = self::PATTERN_OPEN
-    ): int
-    {
+    ): int {
         Assertion::file($file);
         Assertion::readable($file);
 

--- a/src/Command/Info.php
+++ b/src/Command/Info.php
@@ -163,8 +163,8 @@ HELP
     /**
      * Renders the list of attributes.
      *
-     * @param OutputInterface $output     the output
-     * @param array           $attributes the list of attributes
+     * @param OutputInterface $output     The output
+     * @param array           $attributes The list of attributes
      */
     private function render(OutputInterface $output, array $attributes): void
     {
@@ -194,12 +194,12 @@ HELP
     /**
      * Renders the contents of an iterator.
      *
-     * @param OutputInterface $output the output handler
-     * @param Traversable     $list   the traversable list
-     * @param bool|int        $indent the indentation level
-     * @param string          $base   the base path
-     * @param Phar            $phar   the PHP archive
-     * @param string          $root   the root path to remove
+     * @param OutputInterface $output The output handler
+     * @param Traversable     $list   The traversable list
+     * @param bool|int        $indent The indentation level
+     * @param string          $base   The base path
+     * @param Phar            $phar   The PHP archive
+     * @param string          $root   The root path to remove
      */
     private function renderContents(
         OutputInterface $output,

--- a/src/Command/Verify.php
+++ b/src/Command/Verify.php
@@ -28,7 +28,6 @@ use Throwable;
 final class Verify extends Command
 {
     private const PHAR_ARG = 'phar';
-    private const NO_EXTENSION_OPT = 'no-extension';
     private const VERBOSITY_LEVEL = OutputInterface::VERBOSITY_VERBOSE;
 
     /**
@@ -42,15 +41,9 @@ final class Verify extends Command
             <<<'HELP'
 The <info>%command.name%</info> command will verify the signature of the PHAR.
 
-By default, the command will use the <comment>phar</comment> extension to perform the
-verification process. However, if the extension is not available, Box will manually
-extract and verify the PHAR's signature. If you require that Box handle the verification
-process, you will need to use the <comment>--no-extension</comment> option.
-
 <question>Why would I require that box handle the verification process?</question>
 
 If you meet all of the following conditions:
- - The <comment>phar</comment> extension installed
  - The <comment>openssl</comment> extension is not installed
  - You need to verify a PHAR signed using a private key
 
@@ -63,12 +56,6 @@ HELP
             self::PHAR_ARG,
             InputArgument::REQUIRED,
             'The PHAR file'
-        );
-        $this->addOption(
-            self::NO_EXTENSION_OPT,
-            null,
-            InputOption::VALUE_NONE,
-            'Do not use the PHAR extension to verify'
         );
     }
 
@@ -94,17 +81,10 @@ HELP
         );
 
         try {
-            if (!$input->getOption(self::NO_EXTENSION_OPT) && extension_loaded('phar')) {
-                $phar = new Phar($pharPath);
+            $phar = new Phar($pharPath);
 
-                $verified = true;
-                $signature = $phar->getSignature();
-            } else {
-                $phar = new Signature($pharPath);
-
-                $verified = $phar->verify();
-                $signature = $phar->get();
-            }
+            $verified = true;
+            $signature = $phar->getSignature();
         } catch (Throwable $throwable) {
             // Continue
 

--- a/src/Command/Verify.php
+++ b/src/Command/Verify.php
@@ -20,7 +20,6 @@ use Phar;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Throwable;

--- a/src/Signature.php
+++ b/src/Signature.php
@@ -18,7 +18,6 @@ use Assert\Assertion;
 use KevinGH\Box\Exception\FileExceptionFactory;
 use KevinGH\Box\Verifier\Hash;
 use KevinGH\Box\Verifier\PublicKeyDelegate;
-use KevinGH\Box\Verifier;
 use PharException;
 
 /**

--- a/src/StubGenerator.php
+++ b/src/StubGenerator.php
@@ -199,7 +199,7 @@ BANNER;
 
             $compactor = new Php(new Tokenizer());
 
-            $file = __DIR__.'/Extract.php';
+            $file = __DIR__.'/Box_Extract.php';
 
             $code = file_get_contents($file);
             $code = $compactor->compact($file, $code);

--- a/tests/ExtractTest.php
+++ b/tests/ExtractTest.php
@@ -15,15 +15,12 @@ declare(strict_types=1);
 namespace KevinGH\Box;
 
 use Box_Extract;
-use function chmod;
-use function chown;
 use Generator;
 use InvalidArgumentException;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamWrapper;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use function touch;
 
 /**
  * @covers \Box_Extract

--- a/tests/StubGeneratorTest.php
+++ b/tests/StubGeneratorTest.php
@@ -222,7 +222,7 @@ STUB
 
         $compactor = new Php(new Tokenizer());
 
-        $file = __DIR__.'/../src/Extract.php';
+        $file = __DIR__.'/../src/Box_Extract.php';
 
         $code = file_get_contents($file);
         $code = $compactor->compact($file, $code);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,6 +16,7 @@ use org\bovigo\vfs\vfsStreamWrapper;
 use function KevinGH\Box\register_aliases;
 
 $loader = require __DIR__.'/../vendor/autoload.php';
+require_once __DIR__.'/../src/Box_Extract.php';
 
 define('BOX_PATH', realpath(__DIR__).'/../');
 


### PR DESCRIPTION
Fix an issue with the `Extract` class which should not be namespaced neither autoloaded.

Also remove the checks of wether or not the PHAR extension is loaded. The extension is present by default since PHP 5.3 so I don't think we should care for now at least.