### PR TITLE
Add more information to logs when building PHAR

### DIFF
--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -14,12 +14,9 @@ declare(strict_types=1);
 
 namespace KevinGH\Box\Command;
 
-use function is_string;
 use KevinGH\Box\Box;
 use KevinGH\Box\Compactor;
 use KevinGH\Box\Configuration;
-use function KevinGH\Box\formatted_filesize;
-use function KevinGH\Box\get_phar_compression_algorithms;
 use KevinGH\Box\Logger\BuildLogger;
 use KevinGH\Box\StubGenerator;
 use RuntimeException;
@@ -30,7 +27,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
-use function var_export;
+use function KevinGH\Box\formatted_filesize;
+use function KevinGH\Box\get_phar_compression_algorithms;
 
 final class Build extends Configurable
 {
@@ -770,7 +768,7 @@ HELP
                 BuildLogger::QUESTION_MARK_PREFIX,
                 sprintf(
                     'Compressing with the algorithm "<comment>%s</comment>"',
-                    array_search($algorithm, get_phar_compression_algorithms())
+                    array_search($algorithm, get_phar_compression_algorithms(), true)
                 ),
                 OutputInterface::VERBOSITY_VERBOSE
             );

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -409,6 +409,8 @@ HELP
 
         $logger = new BuildLogger($io);
 
+        $startTime = microtime(true);
+
         $this->loadBootstrapFile($config, $logger);
         $this->removeExistingPhar($config, $logger);
 
@@ -423,9 +425,20 @@ HELP
             'Done.'
         );
 
+        if ($io->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
+            $io->comment(
+                sprintf(
+                    '<info>Memory usage: %.2fMB (peak: %.2fMB), time: %.2fs<info>',
+                    round(memory_get_usage() / 1024 / 1024, 2),
+                    round(memory_get_peak_usage() / 1024 / 1024, 2),
+                    round(microtime(true) - $startTime, 2)
+                )
+            );
+        }
+
         if (false === file_exists($path)) {
             //TODO: check that one
-            $io->warning('The archive was not generated because it did not have any contents.');
+            $io->warning('The archive was not generated because it did not have any contents');
         }
     }
 
@@ -468,7 +481,7 @@ HELP
         $logger->log(
             BuildLogger::QUESTION_MARK_PREFIX,
             sprintf(
-                'Loading the bootstrap file "%s".',
+                'Loading the bootstrap file "%s"',
                 $file
             ),
             OutputInterface::VERBOSITY_VERBOSE
@@ -488,7 +501,7 @@ HELP
         $logger->log(
             BuildLogger::QUESTION_MARK_PREFIX,
             sprintf(
-                'Removing the existing PHAR "%s".',
+                'Removing the existing PHAR "%s"',
                 $path
             ),
             OutputInterface::VERBOSITY_VERBOSE
@@ -507,7 +520,7 @@ HELP
 
         $logger->log(
             BuildLogger::QUESTION_MARK_PREFIX,
-            'Setting replacement values.',
+            'Setting replacement values',
             OutputInterface::VERBOSITY_VERBOSE
         );
 
@@ -569,7 +582,7 @@ HELP
 
         $logger->log(
             BuildLogger::QUESTION_MARK_PREFIX,
-            'Mapping paths.',
+            'Mapping paths',
             OutputInterface::VERBOSITY_VERBOSE
         );
 
@@ -597,7 +610,7 @@ HELP
         if ([] !== ($iterators = $config->getFilesIterators())) {
             $logger->log(
                 BuildLogger::QUESTION_MARK_PREFIX,
-                'Adding finder files.',
+                'Adding finder files',
                 OutputInterface::VERBOSITY_VERBOSE
             );
 
@@ -609,7 +622,7 @@ HELP
         if ([] !== ($iterators = $config->getBinaryIterators())) {
             $logger->log(
                 BuildLogger::QUESTION_MARK_PREFIX,
-                'Adding binary finder files.',
+                'Adding binary finder files',
                 OutputInterface::VERBOSITY_VERBOSE
             );
 
@@ -622,7 +635,7 @@ HELP
             $config,
             $box,
             $config->getDirectoriesIterator(),
-            'Adding directories.',
+            'Adding directories',
             false,
             $logger
         );
@@ -631,7 +644,7 @@ HELP
             $config,
             $box,
             $config->getBinaryDirectoriesIterator(),
-            'Adding binary directories.',
+            'Adding binary directories',
             true,
             $logger
         );
@@ -640,7 +653,7 @@ HELP
             $config,
             $box,
             $config->getFilesIterator(),
-            'Adding files.',
+            'Adding files',
             false,
             $logger
         );
@@ -649,7 +662,7 @@ HELP
             $config,
             $box,
             $config->getBinaryFilesIterator(),
-            'Adding binary files.',
+            'Adding binary files',
             true,
             $logger
         );
@@ -698,7 +711,7 @@ HELP
         if (true === $config->isStubGenerated()) {
             $logger->log(
                 BuildLogger::QUESTION_MARK_PREFIX,
-                'Generating new stub.',
+                'Generating new stub',
                 OutputInterface::VERBOSITY_VERBOSE
             );
 
@@ -721,7 +734,7 @@ HELP
         } else {
             $logger->log(
                 BuildLogger::QUESTION_MARK_PREFIX,
-                'Using default stub.',
+                'Using default stub',
                 OutputInterface::VERBOSITY_VERBOSE
             );
         }
@@ -732,7 +745,7 @@ HELP
         if (null !== ($metadata = $config->getMetadata())) {
             $logger->log(
                 BuildLogger::QUESTION_MARK_PREFIX,
-                'Setting metadata.',
+                'Setting metadata',
                 OutputInterface::VERBOSITY_VERBOSE
             );
 
@@ -788,7 +801,7 @@ HELP
 
         $logger->log(
             BuildLogger::QUESTION_MARK_PREFIX,
-            'Signing using a private key.',
+            'Signing using a private key',
             OutputInterface::VERBOSITY_VERBOSE
         );
 
@@ -825,7 +838,7 @@ HELP
         if (null !== ($chmod = $config->getFileMode())) {
             $logger->log(
                 BuildLogger::QUESTION_MARK_PREFIX,
-                'Setting file permissions.',
+                'Setting file permissions',
                 OutputInterface::VERBOSITY_VERBOSE
             );
 

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 
 namespace KevinGH\Box\Command;
 
+use function is_string;
 use KevinGH\Box\Box;
 use KevinGH\Box\Compactor;
 use KevinGH\Box\Configuration;
+use function KevinGH\Box\formatted_filesize;
 use function KevinGH\Box\get_phar_compression_algorithms;
 use KevinGH\Box\Logger\BuildLogger;
 use KevinGH\Box\StubGenerator;
@@ -28,6 +30,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
+use function var_export;
 
 final class Build extends Configurable
 {
@@ -428,7 +431,8 @@ HELP
         if ($io->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
             $io->comment(
                 sprintf(
-                    '<info>Memory usage: %.2fMB (peak: %.2fMB), time: %.2fs<info>',
+                    "<info>Size: %s\nMemory usage: %.2fMB (peak: %.2fMB), time: %.2fs<info>",
+                    formatted_filesize($path),
                     round(memory_get_usage() / 1024 / 1024, 2),
                     round(memory_get_peak_usage() / 1024 / 1024, 2),
                     round(microtime(true) - $startTime, 2)
@@ -749,6 +753,12 @@ HELP
                 OutputInterface::VERBOSITY_VERBOSE
             );
 
+            $logger->log(
+                BuildLogger::MINUS_PREFIX,
+                is_string($metadata) ? $metadata : var_export($metadata, true),
+                OutputInterface::VERBOSITY_VERBOSE
+            );
+
             $box->getPhar()->setMetadata($metadata);
         }
     }
@@ -838,7 +848,7 @@ HELP
         if (null !== ($chmod = $config->getFileMode())) {
             $logger->log(
                 BuildLogger::QUESTION_MARK_PREFIX,
-                'Setting file permissions',
+                "Setting file permissions to <comment>$chmod</comment>",
                 OutputInterface::VERBOSITY_VERBOSE
             );
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -14,14 +14,12 @@ declare(strict_types=1);
 
 namespace KevinGH\Box;
 
-use function array_keys;
 use ArrayIterator;
 use Assert\Assertion;
 use Closure;
 use DateTimeImmutable;
 use Herrera\Annotations\Tokenizer;
 use Herrera\Box\Compactor\Php as LegacyPhp;
-use function implode;
 use InvalidArgumentException;
 use KevinGH\Box\Compactor\Php;
 use Phar;

--- a/src/functions.php
+++ b/src/functions.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 
 namespace KevinGH\Box;
 
+use Assert\Assertion;
 use Phar;
 use ReflectionClass;
+use function sprintf;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
 
@@ -51,6 +53,26 @@ function get_phar_compression_algorithms(): array
     ];
 
     return $algorithms;
+}
+
+function formatted_filesize(string $path)
+{
+    Assertion::file($path);
+
+    $size = filesize($path);
+    $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+    $power = $size > 0 ? floor(log($size, 1024)) : 0;
+
+    return sprintf(
+        '%s%s',
+        number_format(
+            $size / (1024 ** $power),
+            2,
+            '.',
+            ','
+        ),
+        $units[$power]
+    );
 }
 
 function register_aliases(): void

--- a/src/functions.php
+++ b/src/functions.php
@@ -16,8 +16,6 @@ namespace KevinGH\Box;
 
 use Assert\Assertion;
 use Phar;
-use ReflectionClass;
-use function sprintf;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
 
@@ -42,7 +40,7 @@ function is_absolute(string $path): bool
 }
 
 /**
- * TODO: this function should be pushed down to the PHAR extension
+ * TODO: this function should be pushed down to the PHAR extension.
  */
 function get_phar_compression_algorithms(): array
 {

--- a/tests/Command/BuildTest.php
+++ b/tests/Command/BuildTest.php
@@ -72,7 +72,6 @@ class BuildTest extends CommandTestCase
             ['interactive' => true]
         );
 
-
         $expected = <<<'OUTPUT'
 
     ____

--- a/tests/Command/BuildTest.php
+++ b/tests/Command/BuildTest.php
@@ -72,14 +72,15 @@ class BuildTest extends CommandTestCase
             ['interactive' => true]
         );
 
+
         $expected = <<<'OUTPUT'
 
-    ____            
+    ____
    / __ )____  _  __
   / __  / __ \| |/_/
- / /_/ / /_/ />  <  
-/_____/\____/_/|_|  
-                    
+ / /_/ / /_/ />  <
+/_____/\____/_/|_|
+
 
 Box (repo)
 
@@ -87,18 +88,19 @@ Building the PHAR "/path/to/tmp/test.phar"
 Private key passphrase:
 * Done.
 
+ // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
+
+
 OUTPUT;
 
-        $expected = str_replace('/path/to/tmp', $this->tmp, $expected);
-        $actual = $commandTester->getDisplay(true);
+        $actual = $this->normalizeDisplay($commandTester->getDisplay(true));
 
-        // Check output logs
-        $this->assertSame($expected, $actual);
+        $this->assertSame($expected, $actual, 'Expected logs to be identical');
 
-        // Check PHAR execution output
         $this->assertSame(
             'Hello, world!',
-            exec('php test.phar')
+            exec('php test.phar'),
+            'Expected PHAR to be executable'
         );
 
         // Check PHAR content
@@ -172,41 +174,43 @@ OUTPUT;
 
         $expected = <<<OUTPUT
 
-    ____            
+    ____
    / __ )____  _  __
   / __  / __ \| |/_/
- / /_/ / /_/ />  <  
-/_____/\____/_/|_|  
-                    
+ / /_/ / /_/ />  <
+/_____/\____/_/|_|
+
 
 Box (repo)
 
-? Loading the bootstrap file "/path/to/tmp/bootstrap.php".
-? Removing the existing PHAR "/path/to/tmp/test.phar".
+? Loading the bootstrap file "/path/to/tmp/bootstrap.php"
+? Removing the existing PHAR "/path/to/tmp/test.phar"
 * Building the PHAR "/path/to/tmp/test.phar"
 ? Registering compactors
   + KevinGH\Box\Compactor\Php
-? Mapping paths.
+? Mapping paths
   - a/deep/test/directory > sub
   - (all) > other/
-? Adding finder files.
-? Adding binary finder files.
-? Adding directories.
-? Adding files.
+? Adding finder files
+? Adding binary finder files
+? Adding directories
+? Adding files
 ? Adding main file: /path/to/tmp/run.php
     > other/run.php
-? Generating new stub.
-? Setting metadata.
+? Generating new stub
+? Setting metadata
 ? No compression
-? Signing using a private key.
+? Signing using a private key
 Private key passphrase:
-? Setting file permissions.
+? Setting file permissions
 * Done.
+
+ // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
+
 
 OUTPUT;
 
-        $expected = str_replace('/path/to/tmp', $this->tmp, $expected);
-        $actual = $commandTester->getDisplay(true);
+        $actual = $this->normalizeDisplay($commandTester->getDisplay(true));
 
         $this->assertSame($expected, $actual);
     }
@@ -258,51 +262,54 @@ OUTPUT;
 
         $expected = <<<OUTPUT
 
-    ____            
+    ____
    / __ )____  _  __
   / __  / __ \| |/_/
- / /_/ / /_/ />  <  
-/_____/\____/_/|_|  
-                    
+ / /_/ / /_/ />  <
+/_____/\____/_/|_|
+
 
 Box (repo)
 
-? Loading the bootstrap file "/path/to/tmp/bootstrap.php".
-? Removing the existing PHAR "/path/to/tmp/test.phar".
+? Loading the bootstrap file "/path/to/tmp/bootstrap.php"
+? Removing the existing PHAR "/path/to/tmp/test.phar"
 * Building the PHAR "/path/to/tmp/test.phar"
 ? Registering compactors
   + KevinGH\Box\Compactor\Php
-? Mapping paths.
+? Mapping paths
   - a/deep/test/directory > sub
   - (all) > other/
-? Adding finder files.
+? Adding finder files
     > other/one/test.php
-? Adding binary finder files.
+? Adding binary finder files
     > other/two/test.png
-? Adding directories.
+? Adding directories
     > sub/test.php
-? Adding files.
+? Adding files
     > other/test.php
 ? Adding main file: /path/to/tmp/run.php
     > other/run.php
-? Generating new stub.
+? Generating new stub
   - Using custom shebang line: #!__PHP_EXECUTABLE__
   - Using custom banner: custom banner
-? Setting metadata.
+? Setting metadata
 ? No compression
-? Signing using a private key.
+? Signing using a private key
 Private key passphrase:
-? Setting file permissions.
+? Setting file permissions
 * Done.
+
+ // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
+
 
 OUTPUT;
 
         $expected = str_replace(
-            ['/path/to/tmp', '__PHP_EXECUTABLE__'],
-            [$this->tmp, (new PhpExecutableFinder())->find()],
+            '__PHP_EXECUTABLE__',
+            (new PhpExecutableFinder())->find(),
             $expected
         );
-        $actual = $commandTester->getDisplay(true);
+        $actual = $this->normalizeDisplay($commandTester->getDisplay(true));
 
         $this->assertSame($expected, $actual);
     }
@@ -354,16 +361,14 @@ OUTPUT;
 
         $expected = '';
 
-        $expected = str_replace('/path/to/tmp', $this->tmp, $expected);
         $actual = $commandTester->getDisplay(true);
 
-        // Check output logs
-        $this->assertSame($expected, $actual);
+        $this->assertSame($expected, $actual, 'Expected output logs to be identical');
 
-        // Check PHAR execution output
         $this->assertSame(
             'Hello, world!',
-            exec('php test.phar')
+            exec('php test.phar'),
+            'Expected PHAR to be executable'
         );
 
         // Check PHAR content
@@ -437,36 +442,39 @@ OUTPUT;
 
         $expected = <<<'OUTPUT'
 
-    ____            
+    ____
    / __ )____  _  __
   / __  / __ \| |/_/
- / /_/ / /_/ />  <  
-/_____/\____/_/|_|  
-                    
+ / /_/ / /_/ />  <
+/_____/\____/_/|_|
+
 
 Box (repo)
 
-? Removing the existing PHAR "/path/to/tmp/default.phar".
+? Removing the existing PHAR "/path/to/tmp/default.phar"
 * Building the PHAR "/path/to/tmp/default.phar"
-? Setting replacement values.
+? Setting replacement values
   + @name@: world
 ? No compactor to register
-? Adding files.
+? Adding files
 ? Adding main file: /path/to/tmp/test.php
-? Generating new stub.
+? Generating new stub
 ? No compression
 * Done.
 
+ // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
+
+
 OUTPUT;
 
-        $expected = str_replace('/path/to/tmp', $this->tmp, $expected);
-        $actual = $commandTester->getDisplay(true);
+        $actual = $this->normalizeDisplay($commandTester->getDisplay(true));
 
         $this->assertSame($expected, $actual);
 
         $this->assertSame(
             'Hello, world!',
-            exec('php default.phar')
+            exec('php default.phar'),
+            'Expected PHAR to be executable'
         );
     }
 
@@ -486,35 +494,38 @@ OUTPUT;
 
         $expected = <<<'OUTPUT'
 
-    ____            
+    ____
    / __ )____  _  __
   / __  / __ \| |/_/
- / /_/ / /_/ />  <  
-/_____/\____/_/|_|  
-                    
+ / /_/ / /_/ />  <
+/_____/\____/_/|_|
+
 
 Box (repo)
 
 * Building the PHAR "/path/to/tmp/default.phar"
-? Setting replacement values.
+? Setting replacement values
   + @name@: world
 ? No compactor to register
-? Adding files.
+? Adding files
 ? Adding main file: /path/to/tmp/test.php
-? Generating new stub.
+? Generating new stub
 ? No compression
 * Done.
 
+ // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
+
+
 OUTPUT;
 
-        $expected = str_replace('/path/to/tmp', $this->tmp, $expected);
-        $actual = $commandTester->getDisplay(true);
+        $actual = $this->normalizeDisplay($commandTester->getDisplay(true));
 
         $this->assertSame($expected, $actual);
 
         $this->assertSame(
             'Hello, world!',
-            exec('php default.phar')
+            exec('php default.phar'),
+            'Expected PHAR to be executable'
         );
     }
 
@@ -535,35 +546,38 @@ OUTPUT;
 
         $expected = <<<OUTPUT
 
-    ____            
+    ____
    / __ )____  _  __
   / __  / __ \| |/_/
- / /_/ / /_/ />  <  
-/_____/\____/_/|_|  
-                    
+ / /_/ / /_/ />  <
+/_____/\____/_/|_|
+
 
 Box (repo)
 
 * Building the PHAR "/path/to/tmp/test.phar"
 ? No compactor to register
-? Adding files.
+? Adding files
   + /path/to/tmp/test.php
 ? Adding main file: /path/to/tmp/test.php
-? Generating new stub.
+? Generating new stub
   - Using custom banner from file: /path/to/tmp/banner
 ? No compression
 * Done.
 
+ // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
+
+
 OUTPUT;
 
-        $expected = str_replace('/path/to/tmp', $this->tmp, $expected);
-        $actual = $commandTester->getDisplay(true);
+        $actual = $this->normalizeDisplay($commandTester->getDisplay(true));
 
         $this->assertSame($expected, $actual);
 
         $this->assertSame(
             'Hello!',
-            exec('php test.phar')
+            exec('php test.phar'),
+            'Expected PHAR to be executable'
         );
     }
 
@@ -582,33 +596,36 @@ OUTPUT;
 
         $expected = <<<OUTPUT
 
-    ____            
+    ____
    / __ )____  _  __
   / __  / __ \| |/_/
- / /_/ / /_/ />  <  
-/_____/\____/_/|_|  
-                    
+ / /_/ / /_/ />  <
+/_____/\____/_/|_|
+
 
 Box (repo)
 
 * Building the PHAR "/path/to/tmp/test.phar"
 ? No compactor to register
-? Adding files.
+? Adding files
 ? Adding main file: /path/to/tmp/test.php
 ? Using stub file: /path/to/tmp/stub.php
 ? No compression
 * Done.
 
+ // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
+
+
 OUTPUT;
 
-        $expected = str_replace('/path/to/tmp', $this->tmp, $expected);
-        $actual = $commandTester->getDisplay(true);
+        $actual = $this->normalizeDisplay($commandTester->getDisplay(true));
 
         $this->assertSame($expected, $actual);
 
         $this->assertSame(
             'Hello!',
-            exec('php test.phar')
+            exec('php test.phar'),
+            'Expected PHAR to be executable'
         );
     }
 
@@ -627,26 +644,28 @@ OUTPUT;
 
         $expected = <<<OUTPUT
 
-    ____            
+    ____
    / __ )____  _  __
   / __  / __ \| |/_/
- / /_/ / /_/ />  <  
-/_____/\____/_/|_|  
-                    
+ / /_/ / /_/ />  <
+/_____/\____/_/|_|
+
 
 Box (repo)
 
 * Building the PHAR "/path/to/tmp/test.phar"
 ? No compactor to register
-? Adding files.
-? Using default stub.
+? Adding files
+? Using default stub
 ? No compression
 * Done.
 
+ // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
+
+
 OUTPUT;
 
-        $expected = str_replace('/path/to/tmp', $this->tmp, $expected);
-        $actual = $commandTester->getDisplay(true);
+        $actual = $this->normalizeDisplay($commandTester->getDisplay(true));
 
         $this->assertSame($expected, $actual);
     }
@@ -666,27 +685,29 @@ OUTPUT;
 
         $expected = <<<OUTPUT
 
-    ____            
+    ____
    / __ )____  _  __
   / __  / __ \| |/_/
- / /_/ / /_/ />  <  
-/_____/\____/_/|_|  
-                    
+ / /_/ / /_/ />  <
+/_____/\____/_/|_|
+
 
 Box (repo)
 
 * Building the PHAR "/path/to/tmp/test.phar"
 ? No compactor to register
-? Adding files.
+? Adding files
 ? Adding main file: /path/to/tmp/test.php
-? Generating new stub.
+? Generating new stub
 ? Compressing with the algorithm "GZ"
 * Done.
 
+ // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
+
+
 OUTPUT;
 
-        $expected = str_replace('/path/to/tmp', $this->tmp, $expected);
-        $actual = $commandTester->getDisplay(true);
+        $actual = $this->normalizeDisplay($commandTester->getDisplay(true));
 
         $this->assertSame($expected, $actual);
 
@@ -698,7 +719,7 @@ OUTPUT;
         $this->assertSame(
             'Hello!',
             exec('php test.phar'),
-            'Expected the PHAR to be executable.'
+            'Expected the PHAR to be executable'
         );
     }
 
@@ -708,5 +729,25 @@ OUTPUT;
     protected function getCommand(): Command
     {
         return new Build();
+    }
+
+    private function normalizeDisplay(string $display)
+    {
+        $display = str_replace($this->tmp, '/path/to/tmp', $display);
+
+        $display = preg_replace(
+            '/\/\/ Memory usage: \d+\.\d{2}MB \(peak: \d+\.\d{2}MB\), time: \d+\.\d{2}s/',
+            '// Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s',
+            $display
+        );
+
+        $lines = explode("\n", $display);
+
+        $lines = array_map(
+            'rtrim',
+            $lines
+        );
+
+        return implode("\n", $lines);
     }
 }

--- a/tests/Command/BuildTest.php
+++ b/tests/Command/BuildTest.php
@@ -88,6 +88,7 @@ Building the PHAR "/path/to/tmp/test.phar"
 Private key passphrase:
 * Done.
 
+ // Size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
 
@@ -199,12 +200,16 @@ Box (repo)
     > other/run.php
 ? Generating new stub
 ? Setting metadata
+  - array (
+  'rand' => $rand,
+)
 ? No compression
 ? Signing using a private key
 Private key passphrase:
-? Setting file permissions
+? Setting file permissions to 493
 * Done.
 
+ // Size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
 
@@ -293,12 +298,16 @@ Box (repo)
   - Using custom shebang line: #!__PHP_EXECUTABLE__
   - Using custom banner: custom banner
 ? Setting metadata
+  - array (
+  'rand' => $rand,
+)
 ? No compression
 ? Signing using a private key
 Private key passphrase:
-? Setting file permissions
+? Setting file permissions to 493
 * Done.
 
+ // Size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
 
@@ -462,6 +471,7 @@ Box (repo)
 ? No compression
 * Done.
 
+ // Size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
 
@@ -513,6 +523,7 @@ Box (repo)
 ? No compression
 * Done.
 
+ // Size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
 
@@ -565,6 +576,7 @@ Box (repo)
 ? No compression
 * Done.
 
+ // Size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
 
@@ -613,6 +625,7 @@ Box (repo)
 ? No compression
 * Done.
 
+ // Size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
 
@@ -660,6 +673,7 @@ Box (repo)
 ? No compression
 * Done.
 
+ // Size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
 
@@ -702,6 +716,7 @@ Box (repo)
 ? Compressing with the algorithm "GZ"
 * Done.
 
+ // Size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
 
@@ -734,6 +749,12 @@ OUTPUT;
     private function normalizeDisplay(string $display)
     {
         $display = str_replace($this->tmp, '/path/to/tmp', $display);
+
+        $display = preg_replace(
+            '/\/\/ Size: \d+\.\d{2}K?B/',
+            '// Size: 100B',
+            $display
+        );
 
         $display = preg_replace(
             '/\/\/ Memory usage: \d+\.\d{2}MB \(peak: \d+\.\d{2}MB\), time: \d+\.\d{2}s/',

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -350,6 +350,8 @@ class ConfigurationTest extends TestCase
 
     /**
      * @dataProvider provideInvalidCompressionAlgorithms
+     *
+     * @param mixed $compression
      */
     public function test_configure_compression_algorithm_with_an_invalid_algorithm($compression, string $errorMessage): void
     {


### PR DESCRIPTION
Closes #6

Add the following elements to the logs when building a PHAR:

- Time & memory usage
- Size of the built PHAR
- The metadata content
- The file permissions used

As well as some tweaks for the log messages.