### PR TITLE
Process files in parallel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^7.1",
         "ext-phar": "*",
+        "amphp/parallel-functions": "^0.1.2",
         "beberlei/assert": "^2.8",
         "herrera-io/annotations": "~1.0",
         "justinrainbow/json-schema": "^1.0",

--- a/tests/Command/BuildTest.php
+++ b/tests/Command/BuildTest.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 
 namespace KevinGH\Box\Command;
 
+use Amp\MultiReasonException;
+use Amp\Parallel\Worker\TaskException;
+use Assert\InvalidArgumentException as AssertInvalidArgumentException;
 use DirectoryIterator;
 use Generator;
-use InvalidArgumentException;
 use KevinGH\Box\Compactor\Php;
 use KevinGH\Box\Test\CommandTestCase;
 use Phar;
@@ -780,8 +782,13 @@ PHP
             );
 
             $this->fail('Expected exception to be thrown.');
-        } catch (InvalidArgumentException $exception) {
-            $this->assertTrue(true);
+        } catch (MultiReasonException $exception) {
+            $this->assertCount(1, $exception->getReasons());
+
+            /** @var TaskException $reason */
+            $reason = $exception->getReasons()[0];
+
+            $this->assertSame(AssertInvalidArgumentException::class, $reason->getName());
         }
     }
 


### PR DESCRIPTION
The process of adding files with Box works like the following:

- Collect all the files to add with `Configuration`
- Add the files to `Box
    - Find the path that will be used to add the file to the PHAR
    - Replace the placeholder values
    - Runs the compactors on the file content
    - Add the file to the PHAR

There is two expansive processes here:

- collecting the files
- processing the file contents

The first one is out of scope of this PR, but this PR address the second point which is reducing the processing time by parallelising this work.

---

Note for myself: extract from this PR building files from an iterator/array of files which will drastically simplify this PR.

- [x] Rework config (https://github.com/humbug/box/pull/34, #42, #43) 
- [x] Rework addFile (https://github.com/humbug/box/pull/36)
- [x] Switch to buildFromFiles (#44)
- [x] Rebase this PR