### PR TITLE
Harden stub tests

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace KevinGH\Box;
 
 use Assert\Assertion;
-use function dirname;
 use KevinGH\Box\Exception\FileExceptionFactory;
 use KevinGH\Box\Exception\OpenSslExceptionFactory;
 use Phar;

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -734,6 +734,10 @@ HELP
 
             $box->registerStub($stub);
         } else {
+            if (null !== $main) {
+                $box->getPhar()->setDefaultStub($main, $main);
+            }
+
             $logger->log(
                 BuildLogger::QUESTION_MARK_PREFIX,
                 'Using default stub',


### PR DESCRIPTION
Harden the tests:

- Check the PHAR files when building in order to test if the mapping is
  working as expected
- Added tests when using Box stub, the default stub or a custom stub
- Fixed an issue when using the default stub: still register the main
  script as the cli & web index script when provided