### PR TITLE
Refactor configuration to leverage utility classes

### DIFF
--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -866,13 +866,13 @@ HELP
     /**
      * Adds files using an iterator.
      *
-     * @param Configuration $config
-     * @param Box $box
-     * @param iterable|SplFileInfo[] $iterator the iterator
-     * @param string $message the message to announce
-     * @param bool $binary Should the adding be binary-safe?
+     * @param Configuration            $config
+     * @param Box                      $box
+     * @param iterable|SplFileInfo[]   $iterator                 the iterator
+     * @param string                   $message                  the message to announce
+     * @param bool                     $binary                   Should the adding be binary-safe?
      * @param RetrieveRelativeBasePath $retrieveRelativeBasePath
-     * @param BuildLogger $logger
+     * @param BuildLogger              $logger
      */
     private function addFilesToBox(
         Configuration $config,

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -692,8 +692,8 @@ HELP
             OutputInterface::VERBOSITY_VERBOSE
         );
 
-        $mapper = $config->getMapper();
-        $pharPath = $mapper($main);
+        $mapFile = $config->getFileMapper();
+        $pharPath = $mapFile($main);
 
         if (null !== $pharPath) {
             $logger->log(
@@ -894,7 +894,7 @@ HELP
         }
 
         $box = $binary ? $box->getPhar() : $box;
-        $mapper = $config->getMapper();
+        $mapFile = $config->getFileMapper();
 
         foreach ($iterator as $file) {
             // @var $file SplFileInfo
@@ -906,7 +906,7 @@ HELP
 
             $relativePath = $retrieveRelativeBasePath($file->getPathname());
 
-            $mapped = $mapper($relativePath);
+            $mapped = $mapFile($relativePath);
 
             if (null !== $mapped) {
                 $relativePath = $mapped;

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -18,6 +18,7 @@ use KevinGH\Box\Box;
 use KevinGH\Box\Compactor;
 use KevinGH\Box\Configuration;
 use KevinGH\Box\Logger\BuildLogger;
+use KevinGH\Box\RetrieveRelativeBasePath;
 use KevinGH\Box\StubGenerator;
 use RuntimeException;
 use SplFileInfo;
@@ -617,7 +618,7 @@ HELP
             );
 
             foreach ($iterators as $iterator) {
-                $this->addFilesToBox($config, $box, $iterator, null, false, $logger);
+                $this->addFilesToBox($config, $box, $iterator, null, false, $config->getBasePathRetriever(), $logger);
             }
         }
 
@@ -629,7 +630,7 @@ HELP
             );
 
             foreach ($iterators as $iterator) {
-                $this->addFilesToBox($config, $box, $iterator, null, true, $logger);
+                $this->addFilesToBox($config, $box, $iterator, null, true, $config->getBasePathRetriever(), $logger);
             }
         }
 
@@ -639,6 +640,7 @@ HELP
             $config->getDirectoriesIterator(),
             'Adding directories',
             false,
+            $config->getBasePathRetriever(),
             $logger
         );
 
@@ -648,6 +650,7 @@ HELP
             $config->getBinaryDirectoriesIterator(),
             'Adding binary directories',
             true,
+            $config->getBasePathRetriever(),
             $logger
         );
 
@@ -657,6 +660,7 @@ HELP
             $config->getFilesIterator(),
             'Adding files',
             false,
+            $config->getBasePathRetriever(),
             $logger
         );
 
@@ -666,6 +670,7 @@ HELP
             $config->getBinaryFilesIterator(),
             'Adding binary files',
             true,
+            $config->getBasePathRetriever(),
             $logger
         );
     }
@@ -861,12 +866,13 @@ HELP
     /**
      * Adds files using an iterator.
      *
-     * @param Configuration          $config
-     * @param Box                    $box
+     * @param Configuration $config
+     * @param Box $box
      * @param iterable|SplFileInfo[] $iterator the iterator
-     * @param string                 $message  the message to announce
-     * @param bool                   $binary   Should the adding be binary-safe?
-     * @param BuildLogger            $logger
+     * @param string $message the message to announce
+     * @param bool $binary Should the adding be binary-safe?
+     * @param RetrieveRelativeBasePath $retrieveRelativeBasePath
+     * @param BuildLogger $logger
      */
     private function addFilesToBox(
         Configuration $config,
@@ -874,6 +880,7 @@ HELP
         ?iterable $iterator,
         ?string $message,
         bool $binary,
+        RetrieveRelativeBasePath $retrieveRelativeBasePath,
         BuildLogger $logger
     ): void {
         static $count = 0;
@@ -897,7 +904,7 @@ HELP
                 gc_collect_cycles();
             }
 
-            $relativePath = $config->retrieveRelativeBasePath($file->getPathname());
+            $relativePath = $retrieveRelativeBasePath($file->getPathname());
 
             $mapped = $mapper($relativePath);
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -73,7 +73,7 @@ final class Configuration
 
     /**
      * @param string                     $alias                     TODO: description
-     * @param RetrieveRelativeBasePath   $basePathRetriever   Utility to private the base path used and be able to retrieve a path relative to it (the base path)
+     * @param RetrieveRelativeBasePath   $basePathRetriever         Utility to private the base path used and be able to retrieve a path relative to it (the base path)
      * @param iterable|SplFileInfo[]     $binaryDirectoriesIterator List of directories containing images or other binary data
      * @param iterable|SplFileInfo[]     $binaryFilesIterator       List of files containing images or other binary data
      * @param iterable[]|SplFileInfo[][] $binaryIterators           List of file iterators returning binary files

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -50,7 +50,7 @@ final class Configuration
     private $mainScriptPath;
     private $mainScriptContent;
     private $map;
-    private $mapper;
+    private $fileMapper;
     private $metadata;
     private $mimetypeMapping;
     private $mungVariables;
@@ -86,8 +86,7 @@ final class Configuration
      * @param null|int                   $fileMode                  File mode in octal form
      * @param null|string                $mainScriptPath            The main script file path
      * @param null|string                $mainScriptContent         The processed content of the main script file
-     * @param string[]                   $map                       The internal file path mapping
-     * @param Closure                    $mapper                    Callable for the configured map
+     * @param MapFile                    $fileMapper                Utility to map the files from outside and inside the PHAR
      * @param mixed                      $metadata                  The PHAR Metadata
      * @param array                      $mimetypeMapping           The file extension MIME type mapping
      * @param array                      $mungVariables             The list of server variables to modify for execution
@@ -123,8 +122,7 @@ final class Configuration
         ?int $fileMode,
         ?string $mainScriptPath,
         ?string $mainScriptContent,
-        array $map,
-        Closure $mapper,
+        MapFile $fileMapper,
         $metadata,
         array $mimetypeMapping,
         array $mungVariables,
@@ -168,8 +166,7 @@ final class Configuration
         $this->fileMode = $fileMode;
         $this->mainScriptPath = $mainScriptPath;
         $this->mainScriptContent = $mainScriptContent;
-        $this->map = $map;
-        $this->mapper = $mapper;
+        $this->fileMapper = $fileMapper;
         $this->metadata = $metadata;
         $this->mimetypeMapping = $mimetypeMapping;
         $this->mungVariables = $mungVariables;
@@ -228,7 +225,7 @@ final class Configuration
         $mainScriptContent = self::retrieveMainScriptContents($mainScriptPath, $basePath);
 
         $map = self::retrieveMap($raw);
-        $mapper = self::retrieveMapper($map);
+        $fileMapper = new MapFile($map);
 
         $metadata = self::retrieveMetadata($raw);
 
@@ -274,8 +271,7 @@ final class Configuration
             $fileMode,
             $mainScriptPath,
             $mainScriptContent,
-            $map,
-            $mapper,
+            $fileMapper,
             $metadata,
             $mimeTypeMapping,
             $mungVariables,
@@ -420,12 +416,12 @@ final class Configuration
      */
     public function getMap(): array
     {
-        return $this->map;
+        return $this->fileMapper->getMap();
     }
 
-    public function getMapper(): Closure
+    public function getFileMapper(): MapFile
     {
-        return $this->mapper;
+        return $this->fileMapper;
     }
 
     /**
@@ -971,7 +967,7 @@ final class Configuration
     }
 
     /**
-     * @return string[]
+     * @return string[][]
      */
     private static function retrieveMap(stdClass $raw): array
     {
@@ -985,7 +981,7 @@ final class Configuration
             $processed = [];
 
             foreach ($item as $match => $replace) {
-                $processed[canonicalize($match)] = canonicalize($replace);
+                $processed[canonicalize(trim($match))] = canonicalize(trim($replace));
             }
 
             if (isset($processed['_empty_'])) {
@@ -998,29 +994,6 @@ final class Configuration
         }
 
         return $map;
-    }
-
-    private static function retrieveMapper(array $map): Closure
-    {
-        return function (string $path) use ($map): ?string {
-            foreach ($map as $item) {
-                foreach ($item as $match => $replace) {
-                    if (empty($match)) {
-                        return $replace.$path;
-                    }
-
-                    if (0 === strpos($path, $match)) {
-                        return preg_replace(
-                            '/^'.preg_quote($match, '/').'/',
-                            $replace,
-                            $path
-                        );
-                    }
-                }
-            }
-
-            return null;
-        };
     }
 
     /**

--- a/src/MapFile.php
+++ b/src/MapFile.php
@@ -2,6 +2,16 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace KevinGH\Box;
 
 /**

--- a/src/MapFile.php
+++ b/src/MapFile.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinGH\Box;
+
+/**
+ * @internal
+ */
+final class MapFile
+{
+    private $map;
+
+    /**
+     * @param string[][] $map
+     */
+    public function __construct(array $map)
+    {
+        $this->map = $map;
+    }
+
+    public function __invoke(string $path): ?string
+    {
+        foreach ($this->map as $item) {
+            foreach ($item as $match => $replace) {
+                if ('' === $match) {
+                    return $replace.$path;
+                }
+
+                if (0 === strpos($path, $match)) {
+                    return preg_replace(
+                        '/^'.preg_quote($match, '/').'/',
+                        $replace,
+                        $path
+                    );
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public function getMap(): array
+    {
+        return $this->map;
+    }
+}

--- a/src/RetrieveRelativeBasePath.php
+++ b/src/RetrieveRelativeBasePath.php
@@ -2,6 +2,16 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace KevinGH\Box;
 
 final class RetrieveRelativeBasePath

--- a/src/RetrieveRelativeBasePath.php
+++ b/src/RetrieveRelativeBasePath.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinGH\Box;
+
+final class RetrieveRelativeBasePath
+{
+    private $basePath;
+    private $basePathRegex;
+
+    public function __construct(string $basePath)
+    {
+        $this->basePath = $basePath;
+        $this->basePathRegex = '/'.preg_quote($basePath.DIRECTORY_SEPARATOR, '/').'/';
+    }
+
+    public function __invoke(string $path)
+    {
+        return preg_replace(
+            $this->basePathRegex,
+            '',
+            $path
+        );
+    }
+
+    public function getBasePath(): string
+    {
+        return $this->basePath;
+    }
+}

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -534,16 +534,16 @@ class ConfigurationTest extends TestCase
             ]
         );
 
-        $mapper = $this->config->getMapper();
+        $mapFile = $this->config->getFileMapper();
 
         $this->assertSame(
             'a/sub/path/file.php',
-            $mapper('first/test/path/sub/path/file.php')
+            $mapFile('first/test/path/sub/path/file.php')
         );
 
         $this->assertSame(
             'b/second/test/path/sub/path/file.php',
-            $mapper('second/test/path/sub/path/file.php')
+            $mapFile('second/test/path/sub/path/file.php')
         );
     }
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -132,7 +132,7 @@ class ConfigurationTest extends TestCase
         $fullPath = $this->config->getBasePath().DIRECTORY_SEPARATOR.'test';
 
         $expected = 'test';
-        $actual = $this->config->retrieveRelativeBasePath($fullPath);
+        $actual = $this->config->getBasePathRetriever()($fullPath);
 
         $this->assertSame($expected, $actual);
     }


### PR DESCRIPTION
Paves the way for #32.

As it stands, #32 requires some functions from `Configuration` which would require `Configuration` to be serializable. This is a lot of work so it makes sense to rather encapsulate some behaviour in utility classes and leverage them instead. As a result only those utility classes would require to be serializable which is trivial.

This also prepares a change for the `Box` class which IMO should handle the file mapping as it already handles the placeholders replacement and compactor processing.