### PR TITLE
Refactor usage of addFile

### DIFF
--- a/fixtures/Compactor/FakeCompactor.php
+++ b/fixtures/Compactor/FakeCompactor.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace KevinGH\Box\Compactor;
+
+use KevinGH\Box\Compactor;
+use KevinGH\Box\NotCallable;
+
+class FakeCompactor implements Compactor
+{
+    use NotCallable;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compact(string $file, string $contents): string
+    {
+        $this->__call(__METHOD__, func_get_args());
+    }
+}

--- a/fixtures/build/dir000/binary
+++ b/fixtures/build/dir000/binary
@@ -1,0 +1,1 @@
+Unreadable content, get out!

--- a/src/Box.php
+++ b/src/Box.php
@@ -61,8 +61,8 @@ final class Box
         $this->phar = $phar;
         $this->file = $file;
 
-        $this->retrieveRelativeBasePath = function (): void {};
-        $this->mapFile = function (): void {};
+        $this->retrieveRelativeBasePath = function (string $path) { return $path; };
+        $this->mapFile = function (): void { };
     }
 
     /**
@@ -162,7 +162,12 @@ final class Box
         if ($binary) {
             $this->phar->addFile($file, $local);
         } else {
-            $this->addFromString($local, $contents);
+            $processedContents = $this->compactContents(
+                $local,
+                $this->replacePlaceholders($contents)
+            );
+
+            $this->phar->addFromString($local, $processedContents);
         }
 
         return $local;
@@ -218,24 +223,6 @@ final class Box
         if (false === @file_put_contents($pubKey, $details['key'])) {
             throw FileExceptionFactory::createForLastError();
         }
-    }
-
-    /**
-     * Adds the contents from a file to the PHAR. The contents will first be compacted and have its placeholders
-     * replaced.
-     *
-     * @param string $local    The local name or path
-     * @param string $contents The contents
-     */
-    private function addFromString(string $local, string $contents): void
-    {
-        $this->phar->addFromString(
-            $local,
-            $this->compactContents(
-                $local,
-                $this->replacePlaceholders($contents)
-            )
-        );
     }
 
     /**

--- a/src/Box.php
+++ b/src/Box.php
@@ -156,7 +156,7 @@ final class Box
         $local = ($this->mapFile)($relativePath);
 
         if (null === $local) {
-            $local = $file;
+            $local = $relativePath;
         }
 
         if ($binary) {

--- a/src/Box.php
+++ b/src/Box.php
@@ -61,8 +61,8 @@ final class Box
         $this->phar = $phar;
         $this->file = $file;
 
-        $this->retrieveRelativeBasePath = function () {};
-        $this->mapFile = function () {};
+        $this->retrieveRelativeBasePath = function (): void {};
+        $this->mapFile = function (): void {};
     }
 
     /**
@@ -139,9 +139,9 @@ final class Box
      * Adds the a file to the PHAR. The contents will first be compacted and have its placeholders
      * replaced.
      *
-     * @param string $file
-     * @param string|null $contents If null the content of the file will be used
-     * @param bool $binary When true means the file content shouldn't be processed
+     * @param string      $file
+     * @param null|string $contents If null the content of the file will be used
+     * @param bool        $binary   When true means the file content shouldn't be processed
      *
      * @return string File local path
      */

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -664,25 +664,20 @@ HELP
             OutputInterface::VERBOSITY_VERBOSE
         );
 
-        $mapFile = $config->getFileMapper();
-        $pharPath = $mapFile($main);
-
-        if (null !== $pharPath) {
-            $logger->log(
-                BuildLogger::CHEVRON_PREFIX,
-                $pharPath,
-                OutputInterface::VERBOSITY_VERBOSE
-            );
-
-            $main = $pharPath;
-        }
-
-        $box->addFromString(
+        $localMain = $box->addFile(
             $main,
             $config->getMainScriptContent()
         );
 
-        return $main;
+        if ($localMain !== $main) {
+            $logger->log(
+                BuildLogger::CHEVRON_PREFIX,
+                $localMain,
+                OutputInterface::VERBOSITY_VERBOSE
+            );
+        }
+
+        return $localMain;
     }
 
     private function registerStub(Configuration $config, Box $box, ?string $main, BuildLogger $logger): void
@@ -871,7 +866,7 @@ HELP
                 gc_collect_cycles();
             }
 
-            $box->addFile((string) $file, $binary);
+            $box->addFile((string) $file, null, $binary);
         }
     }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -951,18 +951,14 @@ final class Configuration
         if (null === $mainScriptPath) {
             return null;
         }
+
         $mainScriptPath = $basePath.DIRECTORY_SEPARATOR.$mainScriptPath;
 
-        if (false === ($contents = @file_get_contents($mainScriptPath))) {
-            $errors = error_get_last();
+        Assertion::readable($mainScriptPath);
 
-            if (null === $errors) {
-                $errors = ['message' => 'Failed to get contents of "'.$mainScriptPath.'""'];
-            }
+        $contents = file_get_contents($mainScriptPath);
 
-            throw new InvalidArgumentException($errors['message']);
-        }
-
+        // Remove the shebang line
         return preg_replace('/^#!.*\s*/', '', $contents);
     }
 

--- a/src/RetrieveRelativeBasePath.php
+++ b/src/RetrieveRelativeBasePath.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 
 namespace KevinGH\Box;
 
+/**
+ * @internal
+ */
 final class RetrieveRelativeBasePath
 {
     private $basePath;

--- a/tests/BoxTest.php
+++ b/tests/BoxTest.php
@@ -14,19 +14,16 @@ declare(strict_types=1);
 
 namespace KevinGH\Box;
 
-use function dirname;
 use Exception;
 use InvalidArgumentException;
 use KevinGH\Box\Compactor\FakeCompactor;
 use KevinGH\Box\Compactor\Php;
-use LogicException;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamWrapper;
 use Phar;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
-use function realpath;
 
 /**
  * @covers \KevinGH\Box\Box

--- a/tests/BoxTest.php
+++ b/tests/BoxTest.php
@@ -17,7 +17,6 @@ namespace KevinGH\Box;
 use Exception;
 use InvalidArgumentException;
 use KevinGH\Box\Compactor\FakeCompactor;
-use KevinGH\Box\Compactor\Php;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamWrapper;
 use Phar;

--- a/tests/Command/BuildTest.php
+++ b/tests/Command/BuildTest.php
@@ -306,13 +306,9 @@ Box (repo)
   - a/deep/test/directory > sub
   - (all) > other/
 ? Adding finder files
-    > other/one/test.php
 ? Adding binary finder files
-    > other/two/test.png
 ? Adding directories
-    > sub/test.php
 ? Adding files
-    > other/test.php
 ? Adding main file: /path/to/tmp/run.php
     > other/run.php
 ? Generating new stub
@@ -713,7 +709,6 @@ Box (repo)
 * Building the PHAR "/path/to/tmp/test.phar"
 ? No compactor to register
 ? Adding files
-  + /path/to/tmp/test.php
 ? Adding main file: /path/to/tmp/test.php
 ? Generating new stub
   - Using custom banner from file: /path/to/tmp/banner

--- a/tests/Command/BuildTest.php
+++ b/tests/Command/BuildTest.php
@@ -57,6 +57,120 @@ class BuildTest extends CommandTestCase
                     'main' => 'run.php',
                     'map' => [
                         ['a/deep/test/directory' => 'sub'],
+                    ],
+                    'metadata' => ['rand' => $rand = random_int(0, mt_getrandmax())],
+                    'output' => 'test.phar',
+                    'shebang' => $shebang,
+                    'stub' => true,
+                ]
+            )
+        );
+
+        $commandTester = $this->getCommandTester();
+
+        $commandTester->setInputs(['test']);
+        $commandTester->execute(
+            ['command' => 'build'],
+            ['interactive' => true]
+        );
+
+        $expected = <<<'OUTPUT'
+
+    ____
+   / __ )____  _  __
+  / __  / __ \| |/_/
+ / /_/ / /_/ />  <
+/_____/\____/_/|_|
+
+
+Box (repo)
+
+Building the PHAR "/path/to/tmp/test.phar"
+Private key passphrase:
+* Done.
+
+ // Size: 100B
+ // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
+
+
+OUTPUT;
+
+        $actual = $this->normalizeDisplay($commandTester->getDisplay(true));
+
+        $this->assertSame($expected, $actual, 'Expected logs to be identical');
+
+        $this->assertSame(
+            'Hello, world!',
+            exec('php test.phar'),
+            'Expected PHAR to be executable'
+        );
+
+        $phar = new Phar('test.phar');
+
+        // Check PHAR content
+        $actualStub = $this->normalizeDisplay($phar->getStub());
+        $expectedStub = <<<PHP
+$shebang
+<?php
+/**
+ * custom banner
+ */
+if (class_exists('Phar')) {
+Phar::mapPhar('alias-test.phar');
+require 'phar://' . __FILE__ . '/run.php';
+}
+__HALT_COMPILER(); ?>
+
+PHP;
+
+        $this->assertSame($expectedStub, $actualStub);
+
+        $this->assertSame(
+            ['rand' => $rand],
+            $phar->getMetadata(),
+            'Expected PHAR metadata to be set'
+        );
+
+        $expectedFiles = [
+            '/one/',
+            '/one/test.php',
+            '/run.php',
+            '/sub/',
+            '/sub/test.php',
+            '/test.php',
+            '/two/',
+            '/two/test.png',
+        ];
+
+        $actualFiles = $this->retrievePharFiles($phar);
+
+        $this->assertSame($expectedFiles, $actualFiles);
+    }
+
+    public function test_it_can_build_a_PHAR_with_complete_mapping(): void
+    {
+        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
+
+        $shebang = sprintf('#!%s', (new PhpExecutableFinder())->find());
+
+        file_put_contents(
+            'box.json',
+            json_encode(
+                [
+                    'alias' => 'alias-test.phar',
+                    'banner' => 'custom banner',
+                    'bootstrap' => 'bootstrap.php',
+                    'chmod' => '0755',
+                    'compactors' => [Php::class],
+                    'directories' => 'a',
+                    'files' => 'test.php',
+                    'finder' => [['in' => 'one']],
+                    'finder-bin' => [['in' => 'two']],
+                    'key' => 'private.key',
+                    'key-pass' => true,
+                    'main' => 'run.php',
+                    'map' => [
+                        ['a/deep/test/directory' => 'sub'],
                         ['' => 'other/'],
                     ],
                     'metadata' => ['rand' => $rand = random_int(0, mt_getrandmax())],

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -477,6 +477,15 @@ class ConfigurationTest extends TestCase
 
     public function test_configure_main_script_content(): void
     {
+        file_put_contents('test.php', 'script content');
+
+        $this->setConfig(['main' => 'test.php']);
+
+        $this->assertSame('script content', $this->config->getMainScriptContent());
+    }
+
+    public function test_main_script_content_ignores_shebang_line(): void
+    {
         file_put_contents('test.php', "#!/usr/bin/env php\ntest");
 
         $this->setConfig(['main' => 'test.php']);
@@ -491,8 +500,8 @@ class ConfigurationTest extends TestCase
 
             $this->fail('Expected exception to be thrown.');
         } catch (InvalidArgumentException $exception) {
-            $this->assertRegExp(
-                '/failed to open stream/i',
+            $this->assertSame(
+                "Path \"{$this->tmp}/test.php\" was expected to be readable.",
                 $exception->getMessage()
             );
         }


### PR DESCRIPTION
Moves the handling of the mapping from the `Build` command to `Box` during the `addFile()`. The `addFile()` command has also been refactored to be able to:

- Add files with a different content than the one found in the file (e.g. for the main script)
- Add binary files (which should not be compressed and neither have their placeholder replaced)