### PR TITLE
Add working-dir option

### DIFF
--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -35,6 +35,8 @@ use function KevinGH\Box\get_phar_compression_algorithms;
 
 final class Build extends Configurable
 {
+    use ChangeableWorkingDirectory;
+
     private const HELP = <<<'HELP'
 The <info>%command.name%</info> command will build a new PHAR based on a variety of settings.
 <comment>
@@ -61,6 +63,8 @@ HELP;
         $this->setName('build');
         $this->setDescription('Builds a new PHAR');
         $this->setHelp(self::HELP);
+
+        $this->configureWorkingDirOption();
     }
 
     /**
@@ -68,6 +72,8 @@ HELP;
      */
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
+        $this->changeWorkingDirectory($input);
+
         $io = new SymfonyStyle($input, $output);
 
         $io->writeln($this->getApplication()->getHelp());

--- a/src/Command/ChangeableWorkingDirectory.php
+++ b/src/Command/ChangeableWorkingDirectory.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace KevinGH\Box\Command;
+
+use Assert\Assertion;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+trait ChangeableWorkingDirectory
+{
+    /**
+     * @internal using a static property as traits cannot have constants
+     */
+    private static $WORKING_DIR_OPT = 'working-dir';
+
+    final public function changeWorkingDirectory(InputInterface $input): void
+    {
+        $workingDir = $input->getOption(self::$WORKING_DIR_OPT);
+
+        if (null === $workingDir) {
+            return;
+        }
+
+        Assertion::directory(
+            $workingDir,
+            'Could not change the working directory to "%s": directory does not exists or file is not a directory.'
+        );
+
+        if (false === chdir($workingDir)) {
+            throw new RuntimeException(
+                sprintf(
+                    'Failed to change the working directory to "%s" from "%s".',
+                    $workingDir,
+                    getcwd()
+                )
+            );
+        }
+    }
+
+    final private function configureWorkingDirOption(): void
+    {
+        $this->addOption(
+            self::$WORKING_DIR_OPT,
+            'd',
+            InputOption::VALUE_REQUIRED,
+            'If specified, use the given directory as working directory.',
+            null
+        );
+    }
+}


### PR DESCRIPTION
Add the option `working-dir|d` to the `build` command in order to execute the build command from a different directory.