### PR TITLE
Remove usage of string constants

### DIFF
--- a/bin/box
+++ b/bin/box
@@ -17,13 +17,6 @@ use Composer\Autoload\ClassLoader;
 use KevinGH\Box\Console\Application;
 use function KevinGH\Box\register_aliases;
 
-/*
- * The project (or Phar) base path.
- *
- * @var string
- */
-define('BOX_PATH', dirname(__DIR__));
-
 if ($uri = Phar::running()) {
     require "$uri/vendor/autoload.php";
 } elseif (class_exists('Extract')) {

--- a/src/Box_Extract.php
+++ b/src/Box_Extract.php
@@ -14,13 +14,6 @@ declare(strict_types=1);
 
 use Assert\Assertion;
 
-/*
- * The open-ended stub pattern.
- *
- * @var string
- */
-define('BOX_EXTRACT_PATTERN_OPEN', '__HALT'."_COMPILER(); ?>\r\n");
-
 /**
  * Extracts a PHAR without the extension.
  *
@@ -36,7 +29,7 @@ final class Box_Extract
     /**
      * @var string The open-ended stub pattern
      */
-    private const PATTERN_OPEN = BOX_EXTRACT_PATTERN_OPEN;
+    private const PATTERN_OPEN = '__HALT'."_COMPILER(); ?>\r\n";
 
     /**
      * @var int The gzip compression flag

--- a/src/Console/ConfigurationHelper.php
+++ b/src/Console/ConfigurationHelper.php
@@ -21,16 +21,10 @@ use Symfony\Component\Console\Helper\Helper;
 use Webmozart\PathUtil\Path;
 use function KevinGH\Box\is_absolute;
 
-/*
- * The Box schema file path.
- *
- * @var string
- */
-define('BOX_SCHEMA_FILE', BOX_PATH.'/res/schema.json');
-
 final class ConfigurationHelper extends Helper
 {
     private const FILE_NAME = 'box.json';
+    private const SCHEMA_FILE = __DIR__.'/../../res/schema.json';
 
     private $json;
 
@@ -90,7 +84,7 @@ final class ConfigurationHelper extends Helper
         $this->json->validate(
             $file,
             $json,
-            $this->json->decodeFile(BOX_SCHEMA_FILE)
+            $this->json->decodeFile(self::SCHEMA_FILE)
         );
 
         return Configuration::create($file, $json);

--- a/tests/Console/ConfigurationHelperTest.php
+++ b/tests/Console/ConfigurationHelperTest.php
@@ -64,11 +64,6 @@ class ConfigurationHelperTest extends TestCase
         remove_dir($this->tmp);
     }
 
-    public function test_schema_constant_is_defined(): void
-    {
-        $this->assertInternalType('string', BOX_SCHEMA_FILE);
-    }
-
     public function test_it_has_a_name(): void
     {
         $this->assertSame('config', $this->helper->getName());

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,9 +16,8 @@ use org\bovigo\vfs\vfsStreamWrapper;
 use function KevinGH\Box\register_aliases;
 
 $loader = require __DIR__.'/../vendor/autoload.php';
-require_once __DIR__.'/../src/Box_Extract.php';
 
-define('BOX_PATH', realpath(__DIR__).'/../');
+require_once __DIR__.'/../src/Box_Extract.php';
 
 vfsStreamWrapper::register();
 


### PR DESCRIPTION
Remove the existence of the constants. They are useful to change the paths used for box even when it is used from the PHAR, but it easily leads to wtf situations I don't really want to deal with for now.