### PR TITLE
Dump files instead of adding strings

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -34,7 +34,7 @@ $config = PhpCsFixer\Config::create()
         'compact_nullable_typehint' => true,
         'header_comment' => ['header' => $header],
         'heredoc_to_nowdoc' => true,
-        'list_syntax' => ['syntax' => 'long'],
+        'list_syntax' => ['syntax' => 'short'],
         'method_argument_space' => ['ensure_fully_multiline' => true],
         'no_extra_consecutive_blank_lines' => [
             'tokens' => [
@@ -57,6 +57,7 @@ $config = PhpCsFixer\Config::create()
         'no_unreachable_default_argument_value' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
+        'no_unused_imports' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
         'php_unit_test_class_requires_covers' => true,

--- a/TODO
+++ b/TODO
@@ -1,0 +1,6 @@
+L2517: vendor/beberlei/assert/lib/Assert/Assertion.php
+if (\strlen($val) > 100) {
+                $val = \substr($val, 0, 97) . '...';
+            }
+
+This is silly, should rely on log_errors_max_len instead

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,9 @@
         "files": [
             "src/FileSystem/file_system.php",
             "src/functions.php"
+        ],
+        "exclude-from-classmap": [
+            "/Test/"
         ]
     },
     "autoload-dev": {

--- a/src/Console/Command/Build.php
+++ b/src/Console/Command/Build.php
@@ -132,9 +132,9 @@ HELP;
         $this->registerCompactors($config, $box, $logger);
         $this->registerFileMapping($config, $box, $logger);
 
-        $this->addFiles($config, $box, $logger);
-
         $main = $this->registerMainScript($config, $box, $logger);
+
+        $this->addFiles($config, $box, $logger);
 
         $this->registerStub($config, $box, $main, $logger);
         $this->configureMetadata($config, $box, $logger);

--- a/src/Test/CommandTestCase.php
+++ b/src/Test/CommandTestCase.php
@@ -15,29 +15,16 @@ declare(strict_types=1);
 namespace KevinGH\Box\Test;
 
 use KevinGH\Box\Console\Application;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
-use function KevinGH\Box\FileSystem\make_tmp_dir;
-use function KevinGH\Box\FileSystem\remove;
 
-abstract class CommandTestCase extends TestCase
+abstract class CommandTestCase extends FileSystemTestCase
 {
     /**
      * @var Application
      */
     protected $application;
-
-    /**
-     * @var string
-     */
-    protected $cwd;
-
-    /**
-     * @var string
-     */
-    protected $tmp;
 
     /**
      * @var string the name of the command
@@ -49,10 +36,7 @@ abstract class CommandTestCase extends TestCase
      */
     protected function setUp(): void
     {
-        $this->cwd = getcwd();
-        $this->tmp = make_tmp_dir('box', __CLASS__);
-
-        chdir($this->tmp);
+        parent::setUp();
 
         $this->application = new Application();
 
@@ -66,11 +50,9 @@ abstract class CommandTestCase extends TestCase
      */
     protected function tearDown(): void
     {
-        chdir($this->cwd);
-
-        remove($this->tmp);
-
         parent::tearDown();
+
+        $this->application = null;
     }
 
     /**

--- a/src/Test/FileSystemTestCase.php
+++ b/src/Test/FileSystemTestCase.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace KevinGH\Box\Test;
+
+use PHPUnit\Framework\TestCase;
+use function KevinGH\Box\FileSystem\make_tmp_dir;
+use function KevinGH\Box\FileSystem\remove;
+
+abstract class FileSystemTestCase extends TestCase
+{
+    /**
+     * @var string
+     */
+    protected $cwd;
+
+    /**
+     * @var string
+     */
+    protected $tmp;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cwd = getcwd();
+        $this->tmp = make_tmp_dir('box', __CLASS__);
+
+        chdir($this->tmp);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        chdir($this->cwd);
+
+        remove($this->tmp);
+    }
+}

--- a/tests/BoxTest.php
+++ b/tests/BoxTest.php
@@ -17,30 +17,19 @@ namespace KevinGH\Box;
 use Exception;
 use InvalidArgumentException;
 use KevinGH\Box\Compactor\FakeCompactor;
+use KevinGH\Box\Test\FileSystemTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamWrapper;
 use Phar;
-use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
-use function KevinGH\Box\FileSystem\make_tmp_dir;
 use function KevinGH\Box\FileSystem\remove;
 
 /**
  * @covers \KevinGH\Box\Box
  */
-class BoxTest extends TestCase
+class BoxTest extends FileSystemTestCase
 {
-    /**
-     * @var string
-     */
-    private $cwd;
-
-    /**
-     * @var string
-     */
-    private $tmp;
-
     /**
      * @var Box
      */
@@ -66,10 +55,7 @@ class BoxTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->cwd = getcwd();
-        $this->tmp = make_tmp_dir('box', __CLASS__);
-
-        chdir($this->tmp);
+        parent::setUp();
 
         $this->box = Box::create('test.phar');
         $this->phar = $this->box->getPhar();
@@ -83,13 +69,11 @@ class BoxTest extends TestCase
      */
     protected function tearDown(): void
     {
-        unset($this->box);
-
-        chdir($this->cwd);
-
-        remove($this->tmp);
-
         parent::tearDown();
+
+        remove($this->box->getPhar());
+
+        unset($this->box);
     }
 
     public function test_it_can_add_a_file_to_the_phar(): void
@@ -512,7 +496,7 @@ STUB;
      */
     public function test_it_can_sign_the_PHAR(): void
     {
-        list($key, $password) = $this->getPrivateKey();
+        [$key, $password] = $this->getPrivateKey();
 
         $phar = $this->box->getPhar();
 
@@ -556,7 +540,7 @@ STUB;
 
     public function test_it_cannot_sign_if_cannot_create_the_public_key(): void
     {
-        list($key, $password) = $this->getPrivateKey();
+        [$key, $password] = $this->getPrivateKey();
 
         mkdir('test.phar.pubkey');
 
@@ -581,7 +565,7 @@ STUB;
     {
         $phar = $this->box->getPhar();
 
-        list($key, $password) = $this->getPrivateKey();
+        [$key, $password] = $this->getPrivateKey();
 
         file_put_contents($file = 'foo', $key);
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -23,34 +23,23 @@ use KevinGH\Box\Compactor\InvalidCompactor;
 use KevinGH\Box\Compactor\Php;
 use KevinGH\Box\Console\ConfigurationHelper;
 use KevinGH\Box\Json\JsonValidationException;
+use KevinGH\Box\Test\FileSystemTestCase;
 use Phar;
-use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 use stdClass;
 use Symfony\Component\Finder\Finder;
 use function iter\fn\method;
-use function KevinGH\Box\FileSystem\make_tmp_dir;
-use function KevinGH\Box\FileSystem\remove;
+use function KevinGH\Box\FileSystem\make_path_absolute;
 
 /**
  * @covers \KevinGH\Box\Configuration
  */
-class ConfigurationTest extends TestCase
+class ConfigurationTest extends FileSystemTestCase
 {
     /**
      * @var Configuration
      */
     private $config;
-
-    /**
-     * @var string
-     */
-    private $cwd;
-
-    /**
-     * @var string
-     */
-    private $tmp;
 
     /**
      * @var string
@@ -62,28 +51,12 @@ class ConfigurationTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->cwd = getcwd();
-        $this->tmp = make_tmp_dir('box', __CLASS__);
+        parent::setUp();
 
-        $this->file = $this->tmp.DIRECTORY_SEPARATOR.'box.json';
-
-        chdir($this->tmp);
+        $this->file = make_path_absolute('box.json', $this->tmp);
+        touch($this->file);
 
         $this->config = Configuration::create($this->file, (object) []);
-
-        touch($this->file);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function tearDown(): void
-    {
-        chdir($this->cwd);
-
-        remove($this->tmp);
-
-        parent::tearDown();
     }
 
     public function test_a_default_alias_is_provided_when_non_has_been_configured(): void
@@ -509,7 +482,7 @@ EOF
 
             $this->fail('Expected exception to be thrown.');
         } catch (InvalidArgumentException $exception) {
-            $filePath = $this->tmp.DIRECTORY_SEPARATOR.'non-existent';
+            $filePath = make_path_absolute('non-existent', $this->tmp);
 
             $this->assertSame(
                 sprintf(

--- a/tests/Console/Command/BuildTest.php
+++ b/tests/Console/Command/BuildTest.php
@@ -25,9 +25,9 @@ use Phar;
 use PharFileInfo;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Traversable;
+use function KevinGH\Box\FileSystem\mirror;
 
 /**
  * @covers \KevinGH\Box\Console\Command\Build
@@ -40,7 +40,7 @@ class BuildTest extends CommandTestCase
 
     public function test_it_can_build_a_PHAR_file(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
 
         $shebang = sprintf('#!%s', (new PhpExecutableFinder())->find());
 
@@ -97,11 +97,11 @@ Building the PHAR "/path/to/tmp/test.phar"
   + KevinGH\Box\Compactor\Php
 ? Mapping paths
   - a/deep/test/directory > sub
+? Adding main file: /path/to/tmp/run.php
 ? Adding binary files
     > 1 file(s)
 ? Adding files
     > 3 file(s)
-? Adding main file: /path/to/tmp/run.php
 ? Generating new stub
 ? Setting metadata
   - array (
@@ -173,7 +173,7 @@ PHP;
 
     public function test_it_can_build_a_PHAR_from_a_different_directory(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
 
         $shebang = sprintf('#!%s', (new PhpExecutableFinder())->find());
 
@@ -226,7 +226,7 @@ PHP;
 
     public function test_it_can_build_a_PHAR_with_complete_mapping(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
 
         $shebang = sprintf('#!%s', (new PhpExecutableFinder())->find());
 
@@ -285,12 +285,12 @@ Building the PHAR "/path/to/tmp/test.phar"
 ? Mapping paths
   - a/deep/test/directory > sub
   - (all) > other/
+? Adding main file: /path/to/tmp/run.php
+    > other/run.php
 ? Adding binary files
     > 1 file(s)
 ? Adding files
     > 3 file(s)
-? Adding main file: /path/to/tmp/run.php
-    > other/run.php
 ? Generating new stub
 ? Setting metadata
   - array (
@@ -363,7 +363,7 @@ PHP;
 
     public function test_it_can_build_a_PHAR_file_in_verbose_mode(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
 
         $shebang = sprintf('#!%s', (new PhpExecutableFinder())->find());
 
@@ -425,12 +425,12 @@ Box (repo)
 ? Mapping paths
   - a/deep/test/directory > sub
   - (all) > other/
+? Adding main file: /path/to/tmp/run.php
+    > other/run.php
 ? Adding binary files
     > 1 file(s)
 ? Adding files
     > 3 file(s)
-? Adding main file: /path/to/tmp/run.php
-    > other/run.php
 ? Generating new stub
 ? Setting metadata
   - array (
@@ -455,7 +455,7 @@ OUTPUT;
 
     public function test_it_can_build_a_PHAR_file_in_very_verbose_mode(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
 
         $shebang = sprintf('#!%s', (new PhpExecutableFinder())->find());
 
@@ -517,12 +517,12 @@ Box (repo)
 ? Mapping paths
   - a/deep/test/directory > sub
   - (all) > other/
+? Adding main file: /path/to/tmp/run.php
+    > other/run.php
 ? Adding binary files
     > 1 file(s)
 ? Adding files
     > 3 file(s)
-? Adding main file: /path/to/tmp/run.php
-    > other/run.php
 ? Generating new stub
   - Using custom shebang line: #!__PHP_EXECUTABLE__
   - Using custom banner: custom banner
@@ -554,7 +554,7 @@ OUTPUT;
 
     public function test_it_can_build_a_PHAR_file_in_quiet_mode(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
 
         $shebang = sprintf('#!%s', (new PhpExecutableFinder())->find());
 
@@ -635,7 +635,7 @@ OUTPUT;
 
     public function test_it_can_build_a_PHAR_file_using_the_PHAR_default_stub(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
 
         $shebang = sprintf('#!%s', (new PhpExecutableFinder())->find());
 
@@ -684,7 +684,7 @@ OUTPUT;
 
     public function test_it_can_build_a_PHAR_file_using_a_custom_stub(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
 
         $shebang = sprintf('#!%s', (new PhpExecutableFinder())->find());
 
@@ -794,7 +794,7 @@ PHP
 
     public function test_it_can_build_a_PHAR_overwriting_an_existing_one_in_verbose_mode(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir002', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir002', $this->tmp);
 
         $commandTester = $this->getCommandTester();
 
@@ -822,11 +822,11 @@ Box (repo)
 ? Setting replacement values
   + @name@: world
 ? No compactor to register
+? Adding main file: /path/to/tmp/test.php
 ? Adding binary files
     > No file found
 ? Adding files
     > 1 file(s)
-? Adding main file: /path/to/tmp/test.php
 ? Generating new stub
 ? No compression
 * Done.
@@ -850,7 +850,7 @@ OUTPUT;
 
     public function test_it_can_build_a_PHAR_with_a_replacement_placeholder(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir001', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir001', $this->tmp);
 
         $commandTester = $this->getCommandTester();
 
@@ -877,11 +877,11 @@ Box (repo)
 ? Setting replacement values
   + @name@: world
 ? No compactor to register
+? Adding main file: /path/to/tmp/test.php
 ? Adding binary files
     > No file found
 ? Adding files
     > 1 file(s)
-? Adding main file: /path/to/tmp/test.php
 ? Generating new stub
 ? No compression
 * Done.
@@ -905,7 +905,7 @@ OUTPUT;
 
     public function test_it_can_build_a_PHAR_with_a_custom_banner(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir003', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir003', $this->tmp);
 
         $commandTester = $this->getCommandTester();
         $commandTester->execute(
@@ -931,11 +931,11 @@ Box (repo)
 
 * Building the PHAR "/path/to/tmp/test.phar"
 ? No compactor to register
+? Adding main file: /path/to/tmp/test.php
 ? Adding binary files
     > No file found
 ? Adding files
     > 1 file(s)
-? Adding main file: /path/to/tmp/test.php
 ? Generating new stub
   - Using custom banner from file: /path/to/tmp/banner
 ? No compression
@@ -960,7 +960,7 @@ OUTPUT;
 
     public function test_it_can_build_a_PHAR_with_a_stub_file(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir004', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir004', $this->tmp);
 
         $commandTester = $this->getCommandTester();
         $commandTester->execute(
@@ -984,11 +984,11 @@ Box (repo)
 
 * Building the PHAR "/path/to/tmp/test.phar"
 ? No compactor to register
+? Adding main file: /path/to/tmp/test.php
 ? Adding binary files
     > No file found
 ? Adding files
     > 1 file(s)
-? Adding main file: /path/to/tmp/test.php
 ? Using stub file: /path/to/tmp/stub.php
 ? No compression
 * Done.
@@ -1012,7 +1012,7 @@ OUTPUT;
 
     public function test_it_can_build_a_PHAR_with_the_default_stub_file(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir005', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir005', $this->tmp);
 
         $commandTester = $this->getCommandTester();
         $commandTester->execute(
@@ -1057,7 +1057,7 @@ OUTPUT;
 
     public function test_it_can_build_a_PHAR_with_compressed_code(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir006', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir006', $this->tmp);
 
         $commandTester = $this->getCommandTester();
         $commandTester->execute(
@@ -1081,11 +1081,11 @@ Box (repo)
 
 * Building the PHAR "/path/to/tmp/test.phar"
 ? No compactor to register
+? Adding main file: /path/to/tmp/test.php
 ? Adding binary files
     > No file found
 ? Adding files
     > 1 file(s)
-? Adding main file: /path/to/tmp/test.php
 ? Generating new stub
 ? Compressing with the algorithm "GZ"
 * Done.
@@ -1114,7 +1114,7 @@ OUTPUT;
 
     public function test_it_can_build_a_PHAR_in_a_non_existent_directory(): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir007', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir007', $this->tmp);
 
         $commandTester = $this->getCommandTester();
         $commandTester->execute(
@@ -1138,11 +1138,11 @@ Box (repo)
 
 * Building the PHAR "/path/to/tmp/foo/bar/test.phar"
 ? No compactor to register
+? Adding main file: /path/to/tmp/test.php
 ? Adding binary files
     > No file found
 ? Adding files
     > 1 file(s)
-? Adding main file: /path/to/tmp/test.php
 ? Generating new stub
 ? No compression
 * Done.
@@ -1169,7 +1169,7 @@ OUTPUT;
      */
     public function test_it_configures_the_PHAR_alias(bool $stub, bool $web): void
     {
-        (new Filesystem())->mirror(self::FIXTURES_DIR.'/dir008', $this->tmp);
+        mirror(self::FIXTURES_DIR.'/dir008', $this->tmp);
 
         file_put_contents(
             'box.json',

--- a/tests/Console/ConfigurationHelperTest.php
+++ b/tests/Console/ConfigurationHelperTest.php
@@ -15,15 +15,13 @@ declare(strict_types=1);
 namespace KevinGH\Box\Console;
 
 use KevinGH\Box\Configuration;
-use PHPUnit\Framework\TestCase;
+use KevinGH\Box\Test\FileSystemTestCase;
 use RuntimeException;
-use function KevinGH\Box\FileSystem\make_tmp_dir;
-use function KevinGH\Box\FileSystem\remove;
 
 /**
  * @covers \KevinGH\Box\Console\ConfigurationHelper
  */
-class ConfigurationHelperTest extends TestCase
+class ConfigurationHelperTest extends FileSystemTestCase
 {
     /**
      * @var ConfigurationHelper
@@ -31,37 +29,13 @@ class ConfigurationHelperTest extends TestCase
     private $helper;
 
     /**
-     * @var string
-     */
-    private $cwd;
-
-    /**
-     * @var string
-     */
-    private $tmp;
-
-    /**
      * {@inheritdoc}
      */
     protected function setUp(): void
     {
-        $this->cwd = getcwd();
-
-        $this->tmp = make_tmp_dir('box', __CLASS__);
+        parent::setUp();
 
         $this->helper = new ConfigurationHelper();
-
-        chdir($this->tmp);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function tearDown(): void
-    {
-        chdir($this->cwd);
-
-        remove($this->tmp);
     }
 
     public function test_it_has_a_name(): void

--- a/tests/ExtractTest.php
+++ b/tests/ExtractTest.php
@@ -17,29 +17,18 @@ namespace KevinGH\Box;
 use Box_Extract;
 use Generator;
 use InvalidArgumentException;
+use KevinGH\Box\Test\FileSystemTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamWrapper;
-use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use function KevinGH\Box\FileSystem\make_tmp_dir;
 use function KevinGH\Box\FileSystem\remove;
 
 /**
  * @covers \Box_Extract
  */
-class ExtractTest extends TestCase
+class ExtractTest extends FileSystemTestCase
 {
     private const FIXTURES_DIR = __DIR__.'/../fixtures/signed_phars';
-
-    /**
-     * @var string
-     */
-    private $cwd;
-
-    /**
-     * @var string
-     */
-    private $tmp;
 
     /**
      * @var string
@@ -51,11 +40,9 @@ class ExtractTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->cwd = getcwd();
-        $this->tmp = make_tmp_dir('box', __CLASS__);
-        $this->extractTmp = Box_Extract::getTmpDir();
+        parent::setUp();
 
-        chdir($this->tmp);
+        $this->extractTmp = Box_Extract::getTmpDir();
     }
 
     /**
@@ -63,11 +50,9 @@ class ExtractTest extends TestCase
      */
     protected function tearDown(): void
     {
-        chdir($this->cwd);
+        parent::tearDown();
 
         remove([$this->tmp, $this->extractTmp]);
-
-        parent::tearDown();
     }
 
     public function test_it_cannot_be_created_for_a_non_existent_file(): void

--- a/tests/Verifier/OpenSslTest.php
+++ b/tests/Verifier/OpenSslTest.php
@@ -15,52 +15,15 @@ declare(strict_types=1);
 namespace KevinGH\Box\Verifier;
 
 use Exception;
+use KevinGH\Box\Test\FileSystemTestCase;
 use PHPUnit\Framework\Error\Warning;
-use PHPUnit\Framework\TestCase;
-use function KevinGH\Box\FileSystem\make_tmp_dir;
-use function KevinGH\Box\FileSystem\remove;
 
 /**
  * @covers \KevinGH\Box\Verifier\OpenSsl
  */
-class OpenSslTest extends TestCase
+class OpenSslTest extends FileSystemTestCase
 {
     public const FIXTURES_DIR = __DIR__.'/../../fixtures/signed_phars';
-
-    /**
-     * @var string
-     */
-    private $cwd;
-
-    /**
-     * @var string
-     */
-    private $tmp;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp(): void
-    {
-        $this->cwd = getcwd();
-        $this->tmp = make_tmp_dir('box', __CLASS__);
-
-        chdir($this->tmp);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function tearDown(): void
-    {
-        unset($this->box, $this->phar);
-
-        chdir($this->cwd);
-
-        remove($this->tmp);
-
-        parent::tearDown();
-    }
 
     public function test_it_can_verify_files(): void
     {

--- a/tests/Verifier/PublicKeyTest.php
+++ b/tests/Verifier/PublicKeyTest.php
@@ -16,48 +16,13 @@ namespace KevinGH\Box\Verifier;
 
 use Exception;
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
-use function KevinGH\Box\FileSystem\make_tmp_dir;
-use function KevinGH\Box\FileSystem\remove;
+use KevinGH\Box\Test\FileSystemTestCase;
 
 /**
  * @covers \KevinGH\Box\Verifier\PublicKey
  */
-class PublicKeyTest extends TestCase
+class PublicKeyTest extends FileSystemTestCase
 {
-    /**
-     * @var string
-     */
-    private $cwd;
-
-    /**
-     * @var string
-     */
-    private $tmp;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp(): void
-    {
-        $this->cwd = getcwd();
-        $this->tmp = make_tmp_dir('box', __CLASS__);
-
-        chdir($this->tmp);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function tearDown(): void
-    {
-        chdir($this->cwd);
-
-        remove($this->tmp);
-
-        parent::tearDown();
-    }
-
     public function test_it_cannot_be_initialised_with_a_non_existent_file(): void
     {
         try {


### PR DESCRIPTION
Although this patch contains a couple of other things, the main change here is how the files are added.
Indeed right now the current process is to process the contents of the files in parallel and then add them one by one to the PHAR.
Instead, this new approach will dump all of those files in a temporary location to take advantage of the `Phar::buildFromDirectory()` method which seems to be order of magnitudes more performant. The result is a **70 to 80% speed improvement**.

Other changes:

- Add a missing rule to PHP-CS-Fixer to get rid of unused use statements
- Adjust PHP-CS-Fixer list config to use the short syntax instead of the
  long one
- Exclude the tests classes (not test cases) from the non-dev code
- Create a new TestCase class to deal with temporary directories
- Register the main script before the files instead of after
- Tweak temporary dir creation to do only 10 attemps maximum