### PR TITLE
Fix canonicalize

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -679,31 +679,12 @@ final class Configuration
 
     private static function normalizeFilePath(string $file, string $basePath): string
     {
-        $file = trim($file);
-
-        if (false === is_absolute_path($file)) {
-            $file = make_path_absolute($file, $basePath);
-        }
-
-        return $file;
+        return make_path_absolute(trim($file), $basePath);
     }
 
     private static function normalizeDirectoryPath(string $directory, string $basePath): string
     {
-        $directory = trim($directory);
-
-        if (false === is_absolute_path($directory)) {
-            $directory = sprintf(
-                '%s%s',
-                $basePath.DIRECTORY_SEPARATOR,
-                rtrim(
-                    canonicalize($directory),
-                    DIRECTORY_SEPARATOR
-                )
-            );
-        }
-
-        return $directory;
+        return make_path_absolute(trim($directory), $basePath);
     }
 
     private static function retrieveBootstrapFile(stdClass $raw, string $basePath): ?string
@@ -714,11 +695,7 @@ final class Configuration
             return null;
         }
 
-        $file = $raw->bootstrap;
-
-        if (false === is_absolute_path($file)) {
-            $file = canonicalize(make_path_absolute($file, $basePath));
-        }
+        $file = self::normalizeFilePath($raw->bootstrap, $basePath);
 
         Assertion::file($file, 'The bootstrap path "%s" is not a file or does not exist.');
 

--- a/src/Console/Command/Build.php
+++ b/src/Console/Command/Build.php
@@ -535,8 +535,9 @@ HELP;
 
         foreach ($map as $item) {
             foreach ($item as $match => $replace) {
-                if (empty($match)) {
+                if ('' === $match) {
                     $match = '(all)';
+                    $replace .= '/';
                 }
 
                 $logger->log(

--- a/src/FileSystem/FileSystem.php
+++ b/src/FileSystem/FileSystem.php
@@ -49,11 +49,7 @@ final class FileSystem extends SymfonyFilesystem
      */
     public function canonicalize(string $path): string
     {
-        $lastChar = substr($path, -1);
-
-        $canonical = Path::canonicalize($path);
-
-        return '/' === $lastChar ? $canonical.$lastChar : $canonical;
+        return Path::canonicalize($path);
     }
 
     /**

--- a/src/MapFile.php
+++ b/src/MapFile.php
@@ -34,7 +34,7 @@ final class MapFile
         foreach ($this->map as $item) {
             foreach ($item as $match => $replace) {
                 if ('' === $match) {
-                    return $replace.$path;
+                    return $replace.'/'.$path;
                 }
 
                 if (0 === strpos($path, $match)) {

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -429,7 +429,7 @@ EOF
                 ],
                 'directories' => [
                     $basePath.'B',
-                    $basePath.'C',
+                    $basePath.'../sub-dir/C/',
                 ],
                 'finder' => [
                     [


### PR DESCRIPTION
In some cases it was more convenient to get the directory path with an ending slash e.g. `dir/`. To achieve that the `canonicalize` function was "hacked", i.e. instead of being a simple proxy to `Path::canonicalize()` it was doing some extra stuff to keep that ending slash.

However this make the `canonicalize` function incorrect. Instead the issue has been fixed at its core: `canonicalize` behaves in a more "standard" way and cases where the ending slash is required are fixed.