### PR TITLE
Fix alias usage with stub generation

### DIFF
--- a/src/Console/Command/Build.php
+++ b/src/Console/Command/Build.php
@@ -339,15 +339,17 @@ HELP;
 
             $box->registerStub($stub);
         } else {
-            $aliasWasAdded = $box->getPhar()->setAlias($config->getAlias());
+            if (null !== $config->getAlias()) {
+                $aliasWasAdded = $box->getPhar()->setAlias($config->getAlias());
 
-            Assertion::true(
-                $aliasWasAdded,
-                sprintf(
-                    'The alias "%s" is invalid. See Phar::setAlias() documentation for more information.',
-                    $config->getAlias()
-                )
-            );
+                Assertion::true(
+                    $aliasWasAdded,
+                    sprintf(
+                        'The alias "%s" is invalid. See Phar::setAlias() documentation for more information.',
+                        $config->getAlias()
+                    )
+                );
+            }
 
             if (null !== $main) {
                 $box->getPhar()->setDefaultStub($main, $main);

--- a/tests/Console/Command/BuildTest.php
+++ b/tests/Console/Command/BuildTest.php
@@ -773,6 +773,42 @@ PHP
         $this->assertSame($stub, $actualStub);
     }
 
+    public function test_it_can_build_a_PHAR_file_using_the_default_stub(): void
+    {
+        mirror(self::FIXTURES_DIR.'/dir000', $this->tmp);
+
+        file_put_contents(
+            'box.json',
+            json_encode(
+                [
+                    'directories' => ['a'],
+                    'files' => ['test.php'],
+                    'finder' => [['in' => 'one']],
+                    'finder-bin' => [['in' => 'two']],
+                    'main' => 'run.php',
+                    'map' => [
+                        ['a/deep/test/directory' => 'sub'],
+                        ['' => 'other/'],
+                    ],
+                    'output' => 'test.phar',
+                ]
+            )
+        );
+
+        $commandTester = $this->getCommandTester();
+
+        $commandTester->execute(
+            ['command' => 'build'],
+            ['interactive' => true]
+        );
+
+        $this->assertSame(
+            'Hello, world!',
+            exec('php test.phar'),
+            'Expected PHAR to be executable'
+        );
+    }
+
     public function test_it_cannot_build_a_PHAR_using_unreadable_files(): void
     {
         touch('test.php');


### PR DESCRIPTION
When the default stub is used, Box was trying to register an alias to the PHAR. However the alias cannot be null or it results in a fatal error.