### PR TITLE
Remove dead code

### DIFF
--- a/src/Console/Command/Build.php
+++ b/src/Console/Command/Build.php
@@ -100,22 +100,15 @@ HELP;
             'Done.'
         );
 
-        if ($io->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
-            $io->comment(
-                sprintf(
-                    "<info>PHAR size: %s\nMemory usage: %.2fMB (peak: %.2fMB), time: %.2fs<info>",
-                    formatted_filesize($path),
-                    round(memory_get_usage() / 1024 / 1024, 2),
-                    round(memory_get_peak_usage() / 1024 / 1024, 2),
-                    round(microtime(true) - $startTime, 2)
-                )
-            );
-        }
-
-        if (false === file_exists($path)) {
-            //TODO: check that one
-            $io->warning('The archive was not generated because it did not have any contents');
-        }
+        $io->comment(
+            sprintf(
+                "<info>PHAR size: %s\nMemory usage: %.2fMB (peak: %.2fMB), time: %.2fs<info>",
+                formatted_filesize($path),
+                round(memory_get_usage() / 1024 / 1024, 2),
+                round(memory_get_peak_usage() / 1024 / 1024, 2),
+                round(microtime(true) - $startTime, 2)
+            )
+        );
     }
 
     private function createPhar(


### PR DESCRIPTION
- Remove the verbosity check: the only verbosity remaining is `quiet` in which case the `$io` won't print anything
- Remove no file exist check: since the Configuration cannot be created with an empty flag anymore this line is no longer reachable