### PR TITLE
Add debug mode

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -314,7 +314,10 @@ final class Box
             return [$local, $processedContents];
         };
 
-        return wait(parallelMap($files, $processFile));
+        return is_debug_enabled()
+            ? array_map($processFile, $files)
+            : wait(parallelMap($files, $processFile))
+        ;
     }
 
     /**

--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -20,11 +20,13 @@ use KevinGH\Box\Box;
 use KevinGH\Box\Compactor;
 use KevinGH\Box\Configuration;
 use KevinGH\Box\Console\Logger\BuildLogger;
+use function KevinGH\Box\enable_debug;
 use KevinGH\Box\MapFile;
 use KevinGH\Box\StubGenerator;
 use RuntimeException;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -58,6 +60,8 @@ information check the documentation online:
 </comment>
 HELP;
 
+    private const DEV_OPTION = 'debug';
+
     /**
      * {@inheritdoc}
      */
@@ -69,6 +73,12 @@ HELP;
         $this->setDescription('Compile an application into a PHAR');
         $this->setHelp(self::HELP);
 
+        $this->addOption(
+            self::DEV_OPTION,
+            null,
+            InputOption::VALUE_NONE
+        );
+
         $this->configureWorkingDirOption();
     }
 
@@ -77,6 +87,10 @@ HELP;
      */
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
+        if (true === $input->getOption(self::DEV_OPTION)) {
+            enable_debug();
+        }
+
         $this->changeWorkingDirectory($input);
 
         $io = new SymfonyStyle($input, $output);

--- a/src/functions.php
+++ b/src/functions.php
@@ -15,7 +15,15 @@ declare(strict_types=1);
 namespace KevinGH\Box;
 
 use Assert\Assertion;
+use function constant;
 use Phar;
+use function define;
+use function defined;
+
+/**
+ * @internal
+ */
+const DEBUG_CONST = 'KevinGH\Box\BOX_DEBUG';
 
 /**
  * TODO: this function should be pushed down to the PHAR extension.
@@ -64,4 +72,14 @@ function register_compactor_aliases(): void
     if (false === class_exists(\Herrera\Box\Compactor\Php::class, false)) {
         class_alias(\KevinGH\Box\Compactor\Php::class, \Herrera\Box\Compactor\Php::class);
     }
+}
+
+function enable_debug(): void
+{
+    define(DEBUG_CONST, true);
+}
+
+function is_debug_enabled(): bool
+{
+    return defined(DEBUG_CONST) && true === constant(DEBUG_CONST);
 }


### PR DESCRIPTION
As of now the closure serialization used for `parallelMap()` does not work with breakpoints. As such
it is very hard to debug the `$processFile` callable. This new debug mode allow to replace the
`parallelMap()` call by a regular `array_map()`.