### PR TITLE
Rework the Composer Orchestrator

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,8 @@
 ### Backward-compatibility (BC) breaks
 
 - The command `info` no longer supports ZIP & TAR based PHARs
+- When using the `PhpScoper` compactor the `scoper-autoload.php` file is no longer dumped. Instead the whitelist statements are directly
+  appended to the existing autoloader which avoids nay extra work for the user.
 
 ## From 3.0.0-alpha.0 to 3.0.0-alpha.1
 

--- a/bin/box
+++ b/bin/box
@@ -25,11 +25,6 @@ $findAutoloader = function () {
         return $autoload;
     }
 
-    if (file_exists($autoload = __DIR__.'/../vendor/scoper-autoload.php')) {
-        // Is scoped (in PHAR or dumped directory)
-        return $autoload;
-    }
-
     if (file_exists($autoload = __DIR__.'/../vendor/autoload.php')) {
         // Is installed locally
         return $autoload;

--- a/src/Composer/ComposerOrchestrator.php
+++ b/src/Composer/ComposerOrchestrator.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 
 namespace KevinGH\Box\Composer;
 
-use Composer\Console\Application as ComposerApplication;
+use Composer\Factory;
+use Composer\IO\NullIO;
 use Humbug\PhpScoper\Autoload\ScoperAutoloadGenerator;
 use Humbug\PhpScoper\Configuration as PhpScoperConfiguration;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\NullOutput;
-use function KevinGH\Box\FileSystem\dump_file;
+use InvalidArgumentException;
+use function KevinGH\Box\FileSystem\append_to_file;
+use function preg_match;
 
 final class ComposerOrchestrator
 {
@@ -29,14 +30,13 @@ final class ComposerOrchestrator
 
     public static function dumpAutoload(?PhpScoperConfiguration $configuration): void
     {
-        // TODO: we are running Composer a first time to assign ComposerApplication#io. However it should be possible
-        // to do without by patching Composer at the core to construct the application with a NullIO
-        $composerApplication = new ComposerApplication();
-        $composerApplication->doRun(new ArrayInput(['--no-plugins' => null]), new NullOutput());
+        try {
+            $composer = Factory::create(new NullIO(), null, true);
+        } catch (InvalidArgumentException $exception) {
+            if (1 !== preg_match('//', 'could not find a composer\.json file')) {
+                throw $exception;
+            }
 
-        $composer = $composerApplication->getComposer(false, true);
-
-        if (null === $composer) {
             return; // No autoload to dump
         }
 
@@ -49,15 +49,27 @@ final class ComposerOrchestrator
         $generator->setDevMode(false);
         $generator->setClassMapAuthoritative(true);
 
-        if (null !== $configuration) {
-            // TODO: make prefix configurable
-            $autoload = (new ScoperAutoloadGenerator($configuration->getWhitelist()))->dump('_HumbugBox');
-
-            // TODO: handle custom vendor dir
-            // TODO: expose the scoper autoload file name via a constant
-            dump_file('vendor/scoper-autoload.php', $autoload);
-        }
-
         $generator->dump($config, $localRepo, $package, $installationManager, 'composer', true);
+
+        if (null !== $configuration) {
+            $autoload = self::generateAutoloadStatements($configuration);
+
+            append_to_file(
+                $config->get('vendor-dir').'/composer/autoload_real.php',
+                $autoload
+            );
+        }
+    }
+
+    private static function generateAutoloadStatements(PhpScoperConfiguration $configuration): string
+    {
+        // TODO: make prefix configurable: https://github.com/humbug/php-scoper/issues/178
+        $autoload = (new ScoperAutoloadGenerator($configuration->getWhitelist()))->dump('_HumbugBox');
+
+        return preg_replace(
+            '/(\\$loader \= .*)|(return \\$loader;)/',
+            '',
+            str_replace('<?php', '', $autoload)
+        );
     }
 }

--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -78,12 +78,14 @@ HELP;
         $this->addOption(
             self::DEBUG_OPTION,
             null,
-            InputOption::VALUE_NONE
+            InputOption::VALUE_NONE,
+            'Dump the files added to the PHAR in a `.box` directory'
         );
         $this->addOption(
             self::DEV_OPTION,
             null,
-            InputOption::VALUE_NONE
+            InputOption::VALUE_NONE,
+            'Skips the compression step'
         );
 
         $this->configureWorkingDirOption();

--- a/src/Console/Command/Info.php
+++ b/src/Console/Command/Info.php
@@ -148,7 +148,7 @@ HELP
         );
 
         $io->writeln('');
-        $io->comment('Run the command with the PHAR path as an argument to get details on the PHAR.');
+        $io->comment('Get a PHAR details by giving its path as an argument.');
 
         return 0;
     }

--- a/tests/Console/Command/InfoTest.php
+++ b/tests/Console/Command/InfoTest.php
@@ -66,8 +66,7 @@ $compression
 Supported Signatures:
 $signatures
 
- // Run the command with the PHAR path as an argument to get details on the
- // PHAR.
+ // Get a PHAR details by giving its path as an argument.
 
 
 OUTPUT;


### PR DESCRIPTION
- No longer depend on the Composer Application to instantiate the Composer class
- No longer dump a `scoper-autoload.php` file and instead append the whitelist statements to
  `autoload.php`