### PR TITLE
Dump all files in debug mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "symfony/filesystem": "^3.4 || ^4.0",
         "symfony/finder": "^3.4 || ^4.0",
         "symfony/process": "^3.4 || ^4.0",
+        "symfony/var-dumper": "^3.4 || ^4.0",
         "tedivm/jshrink": "~1.0",
         "webmozart/path-util": "^2.3"
     },
@@ -40,8 +41,7 @@
         "bamarni/composer-bin-plugin": "^1.2",
         "infection/infection": "^0.8",
         "mikey179/vfsStream": "^1.1",
-        "phpunit/phpunit": "^7.0",
-        "symfony/var-dumper": "^3.4 || ^4.0"
+        "phpunit/phpunit": "^7.0"
     },
     "suggest": {
         "ext-openssl": "To accelerate private key generation."

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e140cc7b922032aaf61ed62dc1bd7500",
+    "content-hash": "7a5d58839da948d6a1eff479e7996115",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2141,6 +2141,61 @@
             "time": "2018-01-30T19:27:44+00:00"
         },
         {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "8eca20c8a369e069d4f4c2ac9895144112867422"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/8eca20c8a369e069d4f4c2ac9895144112867422",
+                "reference": "8eca20c8a369e069d4f4c2ac9895144112867422",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-01-31T17:43:24+00:00"
+        },
+        {
             "name": "symfony/process",
             "version": "v4.0.4",
             "source": {
@@ -2236,6 +2291,75 @@
                 "distribution"
             ],
             "time": "2017-11-10T15:30:47+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "6d63cc74f3e2d4961411ccb77389a00332653104"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/6d63cc74f3e2d4961411ccb77389a00332653104",
+                "reference": "6d63cc74f3e2d4961411ccb77389a00332653104",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php72": "~1.5"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "twig/twig": "~1.34|~2.4"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-intl": "To show region name in time zone dump"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2018-01-29T09:06:29+00:00"
         },
         {
             "name": "tedivm/jshrink",
@@ -3840,130 +3964,6 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php72",
-            "version": "v1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "8eca20c8a369e069d4f4c2ac9895144112867422"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/8eca20c8a369e069d4f4c2ac9895144112867422",
-                "reference": "8eca20c8a369e069d4f4c2ac9895144112867422",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php72\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2018-01-31T17:43:24+00:00"
-        },
-        {
-            "name": "symfony/var-dumper",
-            "version": "v4.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "6d63cc74f3e2d4961411ccb77389a00332653104"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/6d63cc74f3e2d4961411ccb77389a00332653104",
-                "reference": "6d63cc74f3e2d4961411ccb77389a00332653104",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php72": "~1.5"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
-            },
-            "require-dev": {
-                "ext-iconv": "*",
-                "twig/twig": "~1.34|~2.4"
-            },
-            "suggest": {
-                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
-                "ext-intl": "To show region name in time zone dump"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "Resources/functions/dump.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Component\\VarDumper\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony mechanism for exploring and dumping PHP variables",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "debug",
-                "dump"
-            ],
-            "time": "2018-01-29T09:06:29+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -62,6 +62,7 @@ BANNER;
     ];
     private const PHP_SCOPER_CONFIG = 'scoper.inc.php';
 
+    private $file;
     private $fileMode;
     private $alias;
     private $basePath;
@@ -151,6 +152,7 @@ BANNER;
             )
         );
 
+        $this->file = $file;
         $this->alias = $alias;
         $this->basePath = $basePath;
         $this->files = $files;
@@ -271,6 +273,11 @@ BANNER;
             $isInterceptFileFuncs,
             $isStubGenerated
         );
+    }
+
+    public function getFile(): ?string
+    {
+        return $this->file;
     }
 
     public function getAlias(): string

--- a/src/functions.php
+++ b/src/functions.php
@@ -19,6 +19,7 @@ use Phar;
 use function constant;
 use function define;
 use function defined;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @internal
@@ -74,9 +75,11 @@ function register_compactor_aliases(): void
     }
 }
 
-function enable_debug(): void
+function enable_debug(OutputInterface $output): void
 {
     define(DEBUG_CONST, true);
+
+    $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
 }
 
 function is_debug_enabled(): bool

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -63,11 +63,18 @@ class ConfigurationTest extends FileSystemTestCase
         $this->config = Configuration::create($this->file, new stdClass());
     }
 
+    public function test_it_can_be_created_with_a_file(): void
+    {
+        $config = Configuration::create('box.json', new stdClass());
+
+        $this->assertSame('box.json', $config->getFile());
+    }
+
     public function test_it_can_be_created_without_a_file(): void
     {
-        Configuration::create(null, new stdClass());
+        $config = Configuration::create(null, new stdClass());
 
-        $this->assertTrue(true);
+        $this->assertNull($config->getFile());
     }
 
     public function test_a_default_alias_is_generted_if_no_alias_is_registered(): void


### PR DESCRIPTION
Debug mode now dumps all the files (the binary files were currently not included). The handling of
the dump has been changed a bit as well: the previous dumped files are now removed in `Compile`
which is more natural and less hacky than in `Box::addFile()`.

The configuration file is dumped as well to ease debugging.

The verbosity is forced to debug when the debug mode is enabled.

Closes #102