### PR TITLE
Simplify PhpScoper integration & Make the scoping prefix unique

### DIFF
--- a/fixtures/PhpScoper/FakePhpScoper.php
+++ b/fixtures/PhpScoper/FakePhpScoper.php
@@ -2,8 +2,17 @@
 
 declare(strict_types=1);
 
-namespace KevinGH\Box\PhpScoper;
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
+namespace KevinGH\Box\PhpScoper;
 
 use Humbug\PhpScoper\Scoper;
 use KevinGH\Box\NotCallable;
@@ -13,7 +22,7 @@ final class FakePhpScoper implements Scoper
     use NotCallable;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function scope(string $filePath, string $contents, string $prefix, array $patchers, array $whitelist): string
     {

--- a/fixtures/PhpScoper/FakePhpScoper.php
+++ b/fixtures/PhpScoper/FakePhpScoper.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinGH\Box\PhpScoper;
+
+
+use Humbug\PhpScoper\Scoper;
+use KevinGH\Box\NotCallable;
+
+final class FakePhpScoper implements Scoper
+{
+    use NotCallable;
+
+    /**
+     * @inheritdoc
+     */
+    public function scope(string $filePath, string $contents, string $prefix, array $patchers, array $whitelist): string
+    {
+        $this->__call(__METHOD__, func_get_args());
+    }
+}

--- a/src/Box.php
+++ b/src/Box.php
@@ -18,6 +18,8 @@ use Assert\Assertion;
 use Humbug\PhpScoper\Console\Configuration as PhpScoperConfiguration;
 use KevinGH\Box\Compactor\PhpScoper;
 use KevinGH\Box\Composer\ComposerOrchestrator;
+use KevinGH\Box\PhpScoper\NullScoper;
+use KevinGH\Box\PhpScoper\Scoper;
 use Phar;
 use RecursiveDirectoryIterator;
 use SplFileInfo;
@@ -73,9 +75,9 @@ final class Box
     private $mapFile;
 
     /**
-     * @var null|PhpScoperConfiguration
+     * @var Scoper
      */
-    private $phpScoperConfig;
+    private $scoper;
 
     private function __construct(Phar $phar, string $file)
     {
@@ -84,6 +86,7 @@ final class Box
 
         $this->basePath = getcwd();
         $this->mapFile = function (): void { };
+        $this->scoper = new NullScoper();
     }
 
     /**
@@ -117,7 +120,7 @@ final class Box
 
         foreach ($this->compactors as $compactor) {
             if ($compactor instanceof PhpScoper) {
-                $this->phpScoperConfig = $compactor->getConfiguration();
+                $this->scoper = $compactor->getScoper();
 
                 break;
             }
@@ -203,7 +206,7 @@ final class Box
             }
 
             // Dump autoload without dev dependencies
-            ComposerOrchestrator::dumpAutoload($this->phpScoperConfig);
+            ComposerOrchestrator::dumpAutoload($this->scoper->getWhitelist(), $this->scoper->getPrefix());
 
             chdir($cwd);
 

--- a/src/Box.php
+++ b/src/Box.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace KevinGH\Box;
 
 use Assert\Assertion;
-use Humbug\PhpScoper\Console\Configuration as PhpScoperConfiguration;
 use KevinGH\Box\Compactor\PhpScoper;
 use KevinGH\Box\Composer\ComposerOrchestrator;
 use KevinGH\Box\PhpScoper\NullScoper;

--- a/src/Compactor/PhpScoper.php
+++ b/src/Compactor/PhpScoper.php
@@ -14,11 +14,9 @@ declare(strict_types=1);
 
 namespace KevinGH\Box\Compactor;
 
-use Humbug\PhpScoper\Configuration as PhpScoperConfiguration;
 use KevinGH\Box\Compactor;
 use KevinGH\Box\PhpScoper\Scoper;
 use Throwable;
-use function uniqid;
 
 /**
  * @private

--- a/src/Compactor/PhpScoper.php
+++ b/src/Compactor/PhpScoper.php
@@ -15,8 +15,8 @@ declare(strict_types=1);
 namespace KevinGH\Box\Compactor;
 
 use Humbug\PhpScoper\Configuration as PhpScoperConfiguration;
-use Humbug\PhpScoper\Scoper;
 use KevinGH\Box\Compactor;
+use KevinGH\Box\PhpScoper\Scoper;
 use Throwable;
 use function uniqid;
 
@@ -26,12 +26,10 @@ use function uniqid;
 final class PhpScoper implements Compactor
 {
     private $scoper;
-    private $config;
 
-    public function __construct(Scoper $scoper, PhpScoperConfiguration $config)
+    public function __construct(Scoper $scoper)
     {
         $this->scoper = $scoper;
-        $this->config = $config;
     }
 
     /**
@@ -40,20 +38,14 @@ final class PhpScoper implements Compactor
     public function compact(string $file, string $contents): string
     {
         try {
-            return $this->scoper->scope(
-                $file,
-                $contents,
-                '_HumbugBox',
-                $this->config->getPatchers(),
-                $this->config->getWhitelist()
-            );
+            return $this->scoper->scope($file, $contents);
         } catch (Throwable $throwable) {
             return $contents;
         }
     }
 
-    public function getConfiguration(): PhpScoperConfiguration
+    public function getScoper(): Scoper
     {
-        return $this->config;
+        return $this->scoper;
     }
 }

--- a/src/Composer/ComposerOrchestrator.php
+++ b/src/Composer/ComposerOrchestrator.php
@@ -17,7 +17,6 @@ namespace KevinGH\Box\Composer;
 use Composer\Factory;
 use Composer\IO\NullIO;
 use Humbug\PhpScoper\Autoload\ScoperAutoloadGenerator;
-use Humbug\PhpScoper\Configuration as PhpScoperConfiguration;
 use InvalidArgumentException;
 use function KevinGH\Box\FileSystem\dump_file;
 use function KevinGH\Box\FileSystem\file_contents;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -22,8 +22,9 @@ use Herrera\Box\Compactor\Php as LegacyPhp;
 use Humbug\PhpScoper\Configuration as PhpScoperConfiguration;
 use InvalidArgumentException;
 use KevinGH\Box\Compactor\Php;
-use KevinGH\Box\Compactor\PhpScoper;
+use KevinGH\Box\Compactor\PhpScoper as PhpScoperCompactor;
 use KevinGH\Box\Composer\ComposerConfiguration;
+use KevinGH\Box\PhpScoper\SimpleScoper;
 use Phar;
 use RuntimeException;
 use SplFileInfo;
@@ -903,10 +904,17 @@ BANNER;
                     return self::createPhpCompactor($raw);
                 }
 
-                if (PhpScoper::class === $class) {
+                if (PhpScoperCompactor::class === $class) {
                     $phpScoperConfig = self::retrievePhpScoperConfig($raw, $basePath);
 
-                    return new PhpScoper(create_scoper(), $phpScoperConfig);
+                    return new PhpScoperCompactor(
+                        new SimpleScoper(
+                            create_scoper(),
+                            uniqid('_HumbugBox', false),
+                            $phpScoperConfig->getWhitelist(),
+                            $phpScoperConfig->getPatchers()
+                        )
+                    );
                 }
 
                 return new $class();

--- a/src/PhpScoper/NullScoper.php
+++ b/src/PhpScoper/NullScoper.php
@@ -2,13 +2,22 @@
 
 declare(strict_types=1);
 
-namespace KevinGH\Box\PhpScoper;
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
+namespace KevinGH\Box\PhpScoper;
 
 final class NullScoper implements Scoper
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function scope(string $filePath, string $contents): string
     {

--- a/src/PhpScoper/NullScoper.php
+++ b/src/PhpScoper/NullScoper.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinGH\Box\PhpScoper;
+
+
+final class NullScoper implements Scoper
+{
+    /**
+     * @inheritdoc
+     */
+    public function scope(string $filePath, string $contents): string
+    {
+        return $contents;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getWhitelist(): array
+    {
+        return [];
+    }
+
+    public function getPrefix(): string
+    {
+        return '';
+    }
+}

--- a/src/PhpScoper/Scoper.php
+++ b/src/PhpScoper/Scoper.php
@@ -2,16 +2,25 @@
 
 declare(strict_types=1);
 
-namespace KevinGH\Box\PhpScoper;
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
+namespace KevinGH\Box\PhpScoper;
 
 interface Scoper
 {
     /**
      * Scope AKA. apply the given prefix to the file in the appropriate way.
      *
-     * @param string     $filePath  File to scope
-     * @param string     $contents  File contents
+     * @param string $filePath File to scope
+     * @param string $contents File contents
      *
      * @return string Contents of the file with the prefix applied
      */

--- a/src/PhpScoper/Scoper.php
+++ b/src/PhpScoper/Scoper.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinGH\Box\PhpScoper;
+
+
+interface Scoper
+{
+    /**
+     * Scope AKA. apply the given prefix to the file in the appropriate way.
+     *
+     * @param string     $filePath  File to scope
+     * @param string     $contents  File contents
+     *
+     * @return string Contents of the file with the prefix applied
+     */
+    public function scope(string $filePath, string $contents): string;
+
+    /**
+     * @return string[]
+     */
+    public function getWhitelist(): array;
+
+    public function getPrefix(): string;
+}

--- a/src/PhpScoper/SimpleScoper.php
+++ b/src/PhpScoper/SimpleScoper.php
@@ -2,8 +2,17 @@
 
 declare(strict_types=1);
 
-namespace KevinGH\Box\PhpScoper;
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
+namespace KevinGH\Box\PhpScoper;
 
 use Humbug\PhpScoper\Scoper as PhpScoper;
 
@@ -23,7 +32,7 @@ final class SimpleScoper implements Scoper
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function scope(string $filePath, string $contents): string
     {
@@ -37,7 +46,7 @@ final class SimpleScoper implements Scoper
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getWhitelist(): array
     {
@@ -45,7 +54,7 @@ final class SimpleScoper implements Scoper
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getPrefix(): string
     {

--- a/src/PhpScoper/SimpleScoper.php
+++ b/src/PhpScoper/SimpleScoper.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinGH\Box\PhpScoper;
+
+
+use Humbug\PhpScoper\Scoper as PhpScoper;
+
+final class SimpleScoper implements Scoper
+{
+    private $scoper;
+    private $prefix;
+    private $whitelist;
+    private $patchers;
+
+    public function __construct(PhpScoper $scoper, string $prefix, array $whitelist, array $patchers)
+    {
+        $this->scoper = $scoper;
+        $this->prefix = $prefix;
+        $this->whitelist = $whitelist;
+        $this->patchers = $patchers;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function scope(string $filePath, string $contents): string
+    {
+        return $this->scoper->scope(
+            $filePath,
+            $contents,
+            $this->prefix,
+            $this->patchers,
+            $this->whitelist
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getWhitelist(): array
+    {
+        return $this->whitelist;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPrefix(): string
+    {
+        return $this->prefix;
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -29,6 +29,7 @@ const DEBUG_CONST = 'KevinGH\Box\BOX_DEBUG';
 
 /**
  * TODO: this function should be pushed down to the PHAR extension.
+ *
  * @private
  */
 function get_phar_compression_algorithms(): array

--- a/tests/Compactor/PhpScoperTest.php
+++ b/tests/Compactor/PhpScoperTest.php
@@ -36,7 +36,7 @@ class PhpScoperTest extends TestCase
 }
 JSON;
 
-        /** @var Scoper|ObjectProphecy $scoper */
+        /** @var ObjectProphecy|Scoper $scoper */
         $scoperProphecy = $this->prophesize(Scoper::class);
         $scoperProphecy->scope($file, $contents)->willReturn($expected = 'Scoped contents');
         /** @var Scoper $scoper */
@@ -61,7 +61,7 @@ JSON;
 }
 JSON;
 
-        /** @var Scoper|ObjectProphecy $scoper */
+        /** @var ObjectProphecy|Scoper $scoper */
         $scoperProphecy = $this->prophesize(Scoper::class);
         $scoperProphecy->scope($file, $contents)->willThrow(new Error());
         /** @var Scoper $scoper */

--- a/tests/Console/Command/InfoTest.php
+++ b/tests/Console/Command/InfoTest.php
@@ -19,6 +19,7 @@ use KevinGH\Box\Console\DisplayNormalizer;
 use Phar;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
+use function preg_replace;
 use function realpath;
 
 /**
@@ -165,13 +166,15 @@ OUTPUT;
 
         $expected = <<<OUTPUT
 
- [ERROR] Could not read the file
-         "$expectedPath".
+ [ERROR] Could not read the file "$expectedPath".
 
 
 OUTPUT;
 
-        $this->assertSame($expected, DisplayNormalizer::removeTrailingSpaces($this->commandTester->getDisplay(true)));
+        $actual = DisplayNormalizer::removeTrailingSpaces($this->commandTester->getDisplay(true));
+        $actual = preg_replace('/file[\ \n]+"/', 'file "', $actual);
+
+        $this->assertSame($expected, $actual);
         $this->assertSame(1, $this->commandTester->getStatusCode());
     }
 
@@ -250,13 +253,15 @@ OUTPUT;
 
         $expected = <<<OUTPUT
 
- [ERROR] Could not read the file
-         "$canonicalizedPath".
+ [ERROR] Could not read the file "$canonicalizedPath".
 
 
 OUTPUT;
 
-        $this->assertSame($expected, DisplayNormalizer::removeTrailingSpaces($this->commandTester->getDisplay(true)));
+        $actual = DisplayNormalizer::removeTrailingSpaces($this->commandTester->getDisplay(true));
+        $actual = preg_replace('/file[\ \n]+"/', 'file "', $actual);
+
+        $this->assertSame($expected, $actual);
         $this->assertSame(1, $this->commandTester->getStatusCode());
     }
 

--- a/tests/PhpScoper/NullScoperTest.php
+++ b/tests/PhpScoper/NullScoperTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinGH\Box\PhpScoper;
+
+
+use PHPUnit\Framework\TestCase;
+
+class NullScoperTest extends TestCase
+{
+    public function test_it_returns_the_content_of_the_file_unchanged()
+    {
+        $file = 'foo';
+        $contents = <<<'JSON'
+{
+    "foo": "bar"
+    
+}
+JSON;
+
+        $scoper = new NullScoper();
+
+        $actual = $scoper->scope($file, $contents);
+
+        $this->assertSame($contents, $actual);
+    }
+
+    public function test_it_exposes_some_elements_of_the_scoping_config()
+    {
+        $scoper = new NullScoper();
+
+        $this->assertSame('', $scoper->getPrefix());
+        $this->assertSame([], $scoper->getWhitelist());
+    }
+}

--- a/tests/PhpScoper/NullScoperTest.php
+++ b/tests/PhpScoper/NullScoperTest.php
@@ -2,14 +2,26 @@
 
 declare(strict_types=1);
 
-namespace KevinGH\Box\PhpScoper;
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
+namespace KevinGH\Box\PhpScoper;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversNothing
+ */
 class NullScoperTest extends TestCase
 {
-    public function test_it_returns_the_content_of_the_file_unchanged()
+    public function test_it_returns_the_content_of_the_file_unchanged(): void
     {
         $file = 'foo';
         $contents = <<<'JSON'
@@ -26,7 +38,7 @@ JSON;
         $this->assertSame($contents, $actual);
     }
 
-    public function test_it_exposes_some_elements_of_the_scoping_config()
+    public function test_it_exposes_some_elements_of_the_scoping_config(): void
     {
         $scoper = new NullScoper();
 

--- a/tests/PhpScoper/SimpleScoperTest.php
+++ b/tests/PhpScoper/SimpleScoperTest.php
@@ -2,10 +2,18 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace KevinGH\Box\PhpScoper;
 
-use Error;
-use Humbug\PhpScoper\Configuration;
 use Humbug\PhpScoper\Scoper;
 use KevinGH\Box\Compactor\PhpScoper;
 use PHPUnit\Framework\TestCase;
@@ -31,7 +39,7 @@ JSON;
         $whitelist = ['Whitelisted\Foo'];
         $patchers = [];
 
-        /** @var PhpScoper|ObjectProphecy $phpScoperProphecy */
+        /** @var ObjectProphecy|PhpScoper $phpScoperProphecy */
         $phpScoperProphecy = $this->prophesize(Scoper::class);
         $phpScoperProphecy
             ->scope($file, $contents, $prefix, $patchers, $whitelist)
@@ -51,7 +59,7 @@ JSON;
         $phpScoperProphecy->scope(Argument::cetera())->shouldHaveBeenCalledTimes(1);
     }
 
-    public function test_it_exposes_some_elements_of_the_scoping_config()
+    public function test_it_exposes_some_elements_of_the_scoping_config(): void
     {
         $prefix = 'HumbugBox';
         $whitelist = ['Whitelisted\Foo'];

--- a/tests/PhpScoper/SimpleScoperTest.php
+++ b/tests/PhpScoper/SimpleScoperTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinGH\Box\PhpScoper;
+
+use Error;
+use Humbug\PhpScoper\Configuration;
+use Humbug\PhpScoper\Scoper;
+use KevinGH\Box\Compactor\PhpScoper;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+
+/**
+ * @covers \KevinGH\Box\PhpScoper\SimpleScoper
+ */
+class SimpleScoperTest extends TestCase
+{
+    public function test_it_scopes_the_file_content(): void
+    {
+        $file = 'foo';
+        $contents = <<<'JSON'
+{
+    "foo": "bar"
+    
+}
+JSON;
+
+        $prefix = 'HumbugBox';
+        $whitelist = ['Whitelisted\Foo'];
+        $patchers = [];
+
+        /** @var PhpScoper|ObjectProphecy $phpScoperProphecy */
+        $phpScoperProphecy = $this->prophesize(Scoper::class);
+        $phpScoperProphecy
+            ->scope($file, $contents, $prefix, $patchers, $whitelist)
+            ->willReturn(
+                $expected = 'Scoped file'
+            )
+        ;
+        /** @var PhpScoper $phpScoper */
+        $phpScoper = $phpScoperProphecy->reveal();
+
+        $scoper = new SimpleScoper($phpScoper, $prefix, $whitelist, $patchers);
+
+        $actual = $scoper->scope($file, $contents);
+
+        $this->assertSame($expected, $actual);
+
+        $phpScoperProphecy->scope(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+
+    public function test_it_exposes_some_elements_of_the_scoping_config()
+    {
+        $prefix = 'HumbugBox';
+        $whitelist = ['Whitelisted\Foo'];
+        $patchers = [];
+
+        $scoper = new SimpleScoper(new FakePhpScoper(), $prefix, $whitelist, $patchers);
+
+        $this->assertSame($prefix, $scoper->getPrefix());
+        $this->assertSame($whitelist, $scoper->getWhitelist());
+    }
+}


### PR DESCRIPTION
Add an adapter for PHP-Scoper which:

- Removes the dependency on the configuration API
- Simplify the scoping signature
- Avoid to pass around the whole PHP-Scoper config

The new integration also ensure the scoping is done with a random prefix.