### PR TITLE
Expose Composer JSON & Lock file contents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,5 +114,6 @@ bin/box.phar: bin/box src vendor
 box_dev.json: box.json.dist
 	cat box.json.dist | sed -E 's/\"key\": \".+\",//g' | sed -E 's/\"algorithm\": \".+\",//g' | sed -E 's/\"alias\": \".+\",//g' > box_dev.json
 
+.PHONY: fixtures/default_stub.php
 fixtures/default_stub.php:
 	bin/generate_default_stub

--- a/src/Box.php
+++ b/src/Box.php
@@ -166,9 +166,8 @@ final class Box
 
     /**
      * @param SplFileInfo[]|string[] $files
-     * @param bool                   $binary
      */
-    public function addFiles(array $files, bool $binary): void
+    public function addFiles(array $files, bool $binary, bool $dumpAutoload = false): void
     {
         $files = array_map(
             function ($file): string {
@@ -204,8 +203,10 @@ final class Box
                 }
             }
 
-            // Dump autoload without dev dependencies
-            ComposerOrchestrator::dumpAutoload($this->scoper->getWhitelist(), $this->scoper->getPrefix());
+            if ($dumpAutoload) {
+                // Dump autoload without dev dependencies
+                ComposerOrchestrator::dumpAutoload($this->scoper->getWhitelist(), $this->scoper->getPrefix());
+            }
 
             chdir($cwd);
 
@@ -222,7 +223,6 @@ final class Box
      * @param string      $file
      * @param null|string $contents If null the content of the file will be used
      * @param bool        $binary   When true means the file content shouldn't be processed
-     * @param string      $root
      *
      * @return string File local path
      */

--- a/src/Composer/ComposerOrchestrator.php
+++ b/src/Composer/ComposerOrchestrator.php
@@ -17,10 +17,8 @@ namespace KevinGH\Box\Composer;
 use Composer\Factory;
 use Composer\IO\NullIO;
 use Humbug\PhpScoper\Autoload\ScoperAutoloadGenerator;
-use InvalidArgumentException;
 use function KevinGH\Box\FileSystem\dump_file;
 use function KevinGH\Box\FileSystem\file_contents;
-use function preg_match;
 use function preg_replace;
 
 /**
@@ -37,15 +35,7 @@ final class ComposerOrchestrator
      */
     public static function dumpAutoload(array $whitelist, string $prefix): void
     {
-        try {
-            $composer = Factory::create(new NullIO(), null, true);
-        } catch (InvalidArgumentException $exception) {
-            if (1 !== preg_match('//', 'could not find a composer\.json file')) {
-                throw $exception;
-            }
-
-            return; // No autoload to dump
-        }
+        $composer = Factory::create(new NullIO(), null, true);
 
         $installationManager = $composer->getInstallationManager();
         $localRepository = $composer->getRepositoryManager()->getLocalRepository();

--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -318,7 +318,7 @@ EOF
         $count = count($config->getFiles());
 
         try {
-            $box->addFiles($config->getFiles(), false);
+            $box->addFiles($config->getFiles(), false, null !== $config->getComposerJson());
         } catch (MultiReasonException $exception) {
             // This exception is handled a different way to give me meaningful feedback to the user
             foreach ($exception->getReasons() as $reason) {

--- a/src/Json/Json.php
+++ b/src/Json/Json.php
@@ -61,6 +61,8 @@ final class Json
     }
 
     /**
+     * @throws ParsingException
+     *
      * @return array|stdClass
      */
     public function decodeFile(string $file, bool $assoc = false)


### PR DESCRIPTION
- Make the `composer.json` and `composer.lock` file paths accessible from the configuration
- Make the decoded contents of those two files accessible from the configuration
- One file does not require the other
- Neither of those files are mandatory but when they are found, they must be valid
- Refactored the `ComposerConfiguration` to leverage the new API
- The autoloader can now be dumped when adding non-binary files to Box provided the `composer.json` file is given
- Always include the `composer.json` and `composer.lock` files to the added files whenever possible