### PR TITLE
Add a no config option for `compile`

### DIFF
--- a/fixtures/build/dir009/box.json
+++ b/fixtures/build/dir009/box.json
@@ -1,0 +1,3 @@
+{
+    "main": "main.php"
+}

--- a/fixtures/build/dir009/index.php
+++ b/fixtures/build/dir009/index.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+echo 'Index';

--- a/fixtures/build/dir009/main.php
+++ b/fixtures/build/dir009/main.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+echo 'Main';

--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -26,6 +26,7 @@ use KevinGH\Box\MapFile;
 use KevinGH\Box\PhpSettingsHandler;
 use KevinGH\Box\StubGenerator;
 use RuntimeException;
+use stdClass;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -74,6 +75,7 @@ HELP;
 
     private const DEBUG_OPTION = 'debug';
     private const DEV_OPTION = 'dev';
+    private const NO_CONFIG_OPTION = 'no-config';
 
     /**
      * {@inheritdoc}
@@ -98,6 +100,12 @@ HELP;
             InputOption::VALUE_NONE,
             'Skips the compression step'
         );
+        $this->addOption(
+            self::NO_CONFIG_OPTION,
+            null,
+            InputOption::VALUE_NONE,
+            'Ignore the config file even when one is specified with the --config option'
+        );
 
         $this->configureWorkingDirOption();
     }
@@ -120,7 +128,10 @@ HELP;
         $io->writeln($this->getApplication()->getHelp());
         $io->writeln('');
 
-        $config = $this->getConfig($input, $output, true);
+        $config = $input->getOption(self::NO_CONFIG_OPTION)
+            ? Configuration::create(null, new stdClass())
+            : $this->getConfig($input, $output, true)
+        ;
         $path = $config->getOutputPath();
 
         $logger = new BuildLogger($io);

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -1689,6 +1689,49 @@ OUTPUT;
         );
     }
 
+    public function test_it_can_build_a_PHAR_ignoring_the_configuration(): void
+    {
+        mirror(self::FIXTURES_DIR.'/dir009', $this->tmp);
+
+        $commandTester = $this->getCommandTester();
+
+        $commandTester->execute(
+            [
+                'command' => 'compile',
+                '--no-config' => null,
+            ],
+            ['interactive' => true]
+        );
+
+        $this->assertSame(
+            'Index',
+            exec('php index.phar'),
+            'Expected PHAR to be executable'
+        );
+    }
+
+    public function test_it_ignores_the_config_given_when_the_no_config_setting_is_set(): void
+    {
+        mirror(self::FIXTURES_DIR.'/dir009', $this->tmp);
+
+        $commandTester = $this->getCommandTester();
+
+        $commandTester->execute(
+            [
+                'command' => 'compile',
+                '--config' => 'box.json',
+                '--no-config' => null,
+            ],
+            ['interactive' => true]
+        );
+
+        $this->assertSame(
+            'Index',
+            exec('php index.phar'),
+            'Expected PHAR to be executable'
+        );
+    }
+
     public function provideAliasConfig(): Generator
     {
         yield [true];


### PR DESCRIPTION
Add a `--no-config` option for the `compile` command which allows to completely ignore any
configuration file found.