### PR TITLE
 Fix PHP-Scoper isolated finder not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !/bin/box.bat
 /dist/
 /fixtures/default_stub.php
+/fixtures/build/dir010/*.phar
 /vendor/
 /vendor-bin/*/composer.lock
 /vendor-bin/*/vendor/

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,8 @@ e2e: box_dev.json
 
 	php box.phar compile
 
+	php bin/box.phar compile --working-dir fixtures/build/dir010
+
 	rm box.phar bin/box.phar
 
 .PHONY: blackfire

--- a/bin/box
+++ b/bin/box
@@ -51,12 +51,12 @@ $findPhpScoperFunctions = function () {
 $bootstrap = function () use ($findAutoloader, $findPhpScoperFunctions): void {
     require_once $findAutoloader();
     require_once $findPhpScoperFunctions();
+
+    \KevinGH\Box\register_aliases();
 };
 $bootstrap();
 
 $GLOBALS['bootstrap'] = $bootstrap;
-
-register_compactor_aliases();
 
 // Convert errors to exceptions
 set_error_handler(

--- a/fixtures/build/dir010/box.json
+++ b/fixtures/build/dir010/box.json
@@ -1,0 +1,5 @@
+{
+    "compactors": [
+        "KevinGH\\Box\\Compactor\\PhpScoper"
+    ]
+}

--- a/fixtures/build/dir010/index.php
+++ b/fixtures/build/dir010/index.php
@@ -1,4 +1,3 @@
-#!/usr/bin/env php
 <?php
 
 declare(strict_types=1);
@@ -13,11 +12,4 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace KevinGH\Box;
-
-use KevinGH\Box\Console\Application;
-
-require __DIR__.'/../src/bootstrap.php';
-
-$app = new Application();
-$app->run();
+echo 'Index';

--- a/fixtures/build/dir010/scoper.inc.php
+++ b/fixtures/build/dir010/scoper.inc.php
@@ -1,4 +1,3 @@
-#!/usr/bin/env php
 <?php
 
 declare(strict_types=1);
@@ -13,11 +12,10 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace KevinGH\Box;
+use Isolated\Symfony\Component\Finder\Finder;
 
-use KevinGH\Box\Console\Application;
-
-require __DIR__.'/../src/bootstrap.php';
-
-$app = new Application();
-$app->run();
+return [
+    'finders' => [
+        Finder::create()->files()->in(__DIR__),
+    ],
+];

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -12,10 +12,17 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
+use Isolated\Symfony\Component\Finder\Finder;
+
 $classLoaderContents = file_get_contents(__DIR__.'/vendor/composer/composer/src/Composer/Autoload/ClassLoader.php');
 
 return [
     'patchers' => [
+        function (string $filePath, string $prefix, string $contents): string {
+            $finderClass = sprintf('\%s\%s', $prefix, Finder::class);
+
+            return str_replace($finderClass, '\\'.Finder::class, $contents);
+        },
         function (string $filePath, string $prefix, string $contents): string {
             $file = 'vendor/beberlei/assert/lib/Assert/Assertion.php';
 
@@ -79,6 +86,8 @@ return [
         },
     ],
     'whitelist' => [
+        \Composer\Autoload\ClassLoader::class,
+
         \Herrera\Box\Compactor\Javascript::class,
         \KevinGH\Box\Compactor\Javascript::class,
         \Herrera\Box\Compactor\Json::class,

--- a/src/FileSystem/file_system.php
+++ b/src/FileSystem/file_system.php
@@ -17,6 +17,7 @@ namespace KevinGH\Box\FileSystem;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Traversable;
+use Webmozart\PathUtil\Path;
 
 /**
  * Canonicalizes the given path.
@@ -295,13 +296,7 @@ function change_extension(string $path, string $extension): string
  */
 function is_absolute_path(string $path): bool
 {
-    static $fileSystem;
-
-    if (null === $fileSystem) {
-        $fileSystem = new FileSystem();
-    }
-
-    return $fileSystem->isAbsolutePath($path);
+    return Path::isAbsolute($path);
 }
 
 /**

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace KevinGH\Box;
+
+use ErrorException;
+use RuntimeException;
+
+$findAutoloader = function () {
+    if (file_exists($autoload = __DIR__.'/../../../autoload.php')) {
+        // Is installed via Composer
+        return $autoload;
+    }
+
+    if (file_exists($autoload = __DIR__.'/../vendor/autoload.php')) {
+        // Is installed locally
+        return $autoload;
+    }
+
+    throw new RuntimeException('Unable to find the Composer or PHP-Scoper autoloader.');
+};
+
+// TODO: update PHP-Scoper to get rid of this horrible hack at some point
+$findPhpScoperFunctions = function () {
+    if (file_exists($autoload = __DIR__.'/../../php-scoper/src/functions.php')) {
+        // Is installed via Composer
+        return $autoload;
+    }
+
+    if (file_exists($autoload = __DIR__.'/../vendor/humbug/php-scoper/src/functions.php')) {
+        // Is scoped (in PHAR or dumped directory) or is installed locally
+        return $autoload;
+    }
+
+    throw new RuntimeException('Unable to find the PHP-Scoper functions.');
+};
+
+$bootstrap = function () use ($findAutoloader, $findPhpScoperFunctions): void {
+    require_once $findAutoloader();
+    require_once $findPhpScoperFunctions();
+
+    \KevinGH\Box\register_aliases();
+};
+$bootstrap();
+
+$GLOBALS['bootstrap'] = $bootstrap;
+
+// Convert errors to exceptions
+set_error_handler(
+    function ($code, $message, $file, $line): void {
+        if (error_reporting() & $code) {
+            throw new ErrorException($message, 0, $code, $file, $line);
+        }
+    }
+);

--- a/src/functions.php
+++ b/src/functions.php
@@ -69,8 +69,14 @@ function formatted_filesize(string $path)
 /**
  * @private
  */
-function register_compactor_aliases(): void
+function register_aliases(): void
 {
+    // Exposes the finder used by PHP-Scoper PHAR to allow its usage in the configuration file.
+    if (false === class_exists(\Isolated\Symfony\Component\Finder\Finder::class)) {
+        class_alias(\Symfony\Component\Finder\Finder::class, \Isolated\Symfony\Component\Finder\Finder::class);
+    }
+
+    // Register compactors aliases
     if (false === class_exists(\Herrera\Box\Compactor\Javascript::class, false)) {
         class_alias(\KevinGH\Box\Compactor\Javascript::class, \Herrera\Box\Compactor\Javascript::class);
     }

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -1732,6 +1732,24 @@ OUTPUT;
         );
     }
 
+    public function test_it_can_build_a_PHAR_with_a_PHPScoper_config(): void
+    {
+        mirror(self::FIXTURES_DIR.'/dir010', $this->tmp);
+
+        $commandTester = $this->getCommandTester();
+
+        $commandTester->execute(
+            ['command' => 'compile'],
+            ['interactive' => true]
+        );
+
+        $this->assertSame(
+            'Index',
+            exec('php index.phar'),
+            'Expected PHAR to be executable'
+        );
+    }
+
     public function provideAliasConfig(): Generator
     {
         yield [true];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
  */
 
 use org\bovigo\vfs\vfsStreamWrapper;
-use function KevinGH\Box\register_compactor_aliases;
+use function KevinGH\Box\register_aliases;
 
 $loader = require __DIR__.'/../vendor/autoload.php';
 
 vfsStreamWrapper::register();
 
-register_compactor_aliases();
+register_aliases();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,10 +13,9 @@ declare(strict_types=1);
  */
 
 use org\bovigo\vfs\vfsStreamWrapper;
-use function KevinGH\Box\register_aliases;
 
-$loader = require __DIR__.'/../vendor/autoload.php';
+$loader = require __DIR__.'/../src/bootstrap.php';
+
+restore_error_handler();
 
 vfsStreamWrapper::register();
-
-register_aliases();


### PR DESCRIPTION
Even though the isolated PHP-Scoper is not used per se (Box does not use the `finders` key from 
 `scoper.inc.php` file), the class will still be loaded and as such requires to be registered.