### PR TITLE
Fixed Scoped Box PHAR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ compile:
 	rm -f bin/box.phar
 
 	# Build the PHAR
-	php -d phar.readonly=0 bin/box compile $(args)
+	php bin/box compile $(args)
 
 
 ##
@@ -41,17 +41,17 @@ test: tu e2e
 .PHONY: tu
 tu:		## Run the unit tests
 tu: vendor/bin/phpunit fixtures/default_stub.php
-	php -d phar.readonly=0 -d zend.enable_gc=0 bin/phpunit
+	php -d zend.enable_gc=0 bin/phpunit
 
 .PHONY: tc
 tc:		## Run the unit tests with code coverage
 tc: vendor/bin/phpunit
-	phpdbg -qrr -d phar.readonly=0 -d zend.enable_gc=0 bin/phpunit --coverage-html=dist/coverage --coverage-text
+	phpdbg -qrr -d zend.enable_gc=0 bin/phpunit --coverage-html=dist/coverage --coverage-text
 
 .PHONY: tm
 tm:		## Run Infection
 tm:	vendor/bin/phpunit fixtures/default_stub.php
-	php -d phar.readonly=0 -d zend.enable_gc=0 bin/infection
+	php -d zend.enable_gc=0 bin/infection
 
 .PHONY: e2e
 e2e:		## Run the end-to-end tests
@@ -61,8 +61,12 @@ e2e: box_dev.json
 	rm box.phar || true
 	mv -v bin/box.phar .
 
-	# TODO: use the build step again otherwise it is going to include the dev files
-	php -d phar.readonly=0 box.phar compile
+	php box.phar compile
+
+	rm box.phar || true
+	mv -v bin/box.phar .
+
+	php box.phar compile
 
 	rm box.phar bin/box.phar
 
@@ -78,11 +82,11 @@ blackfire: bin/box src vendor
 	composer dump-autoload --classmap-authoritative
 
 	# Profile compiling the PHAR from the source code
-	blackfire --reference=1 --samples=5 run php -d zend.enable_gc=0 -d phar.readonly=0 bin/box compile --quiet
+	blackfire --reference=1 --samples=5 run php -d zend.enable_gc=0 bin/box compile --quiet
 
 	# Profile compiling the PHAR from the PHAR
 	mv -fv bin/box.phar .
-	blackfire --reference=2 --samples=5 run php -d zend.enable_gc=0 -d phar.readonly=0 box.phar compile --quiet
+	blackfire --reference=2 --samples=5 run php -d zend.enable_gc=0 box.phar compile --quiet
 
 	# Cleanup
 	composer install

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
+$classLoaderContents = file_get_contents(__DIR__.'/vendor/composer/composer/src/Composer/Autoload/ClassLoader.php');
+
 return [
     'patchers' => [
         function (string $filePath, string $prefix, string $contents): string {
@@ -57,6 +59,23 @@ return [
                 '\\KevinGH\\\Box\\Compactor\\',
                 $contents
             );
+        },
+        function (string $filePath, string $prefix, string $contents): string {
+            if ('vendor/composer/composer/src/Composer/Autoload/AutoloadGenerator.php' !== $filePath) {
+                return $contents;
+            }
+
+            return preg_replace(
+                sprintf(
+                    '/\$loader = new \\\\%s\\\\Composer\\\\Autoload\\\\ClassLoader\(\)/',
+                    $prefix
+                ),
+                '$loader = new \Composer\Autoload\ClassLoader();',
+                $contents
+            );
+        },
+        function (string $filePath, string $prefix, string $contents) use ($classLoaderContents): string {
+            return 'vendor/composer/composer/src/Composer/Autoload/ClassLoader.php' === $filePath ? $classLoaderContents : $contents;
         },
     ],
     'whitelist' => [


### PR DESCRIPTION
Fixed an issue where the scoped PHAR created by a scoped Box had its autoloading broken and was
unable to dump the autoloader manipulating Composer directly (as a dependency).