### PR TITLE
Make compilation faster in debug mode and added new compilation options

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -198,10 +198,6 @@ final class Box
                 [$file, $contents] = $fileWithContents;
 
                 dump_file($file, $contents);
-
-                if (is_debug_enabled()) {
-                    dump_file($cwd.'/'.self::DEBUG_DIR.'/'.$file, $contents);
-                }
             }
 
             if ($dumpAutoload) {
@@ -250,14 +246,6 @@ final class Box
             );
 
             $this->phar->addFromString($local, $processedContents);
-        }
-
-        if (is_debug_enabled()) {
-            if (false === isset($processedContents)) {
-                $processedContents = $contents;
-            }
-
-            dump_file(self::DEBUG_DIR.DIRECTORY_SEPARATOR.$relativePath, $processedContents);
         }
 
         return $local;
@@ -351,9 +339,9 @@ final class Box
             return [$local, $processedContents];
         };
 
-        return is_debug_enabled()
-            ? array_map($processFile, $files)
-            : wait(parallelMap($files, $processFile))
+        return is_parallel_processing_enabled()
+            ? wait(parallelMap($files, $processFile))
+            : array_map($processFile, $files)
         ;
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -25,7 +25,7 @@ use function defined;
  * @internal
  * @private
  */
-const DEBUG_CONST = 'KevinGH\Box\BOX_DEBUG';
+const NO_PARALLEL_PROCESSING = 'KevinGH\Box\BOX_NO_PARALLEL_PROCESSING';
 
 /**
  * TODO: this function should be pushed down to the PHAR extension.
@@ -93,17 +93,15 @@ function register_aliases(): void
 /**
  * @private
  */
-function enable_debug(OutputInterface $output): void
+function disable_parallel_processing(): void
 {
-    define(DEBUG_CONST, true);
-
-    $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
+    define(NO_PARALLEL_PROCESSING, true);
 }
 
 /**
  * @private
  */
-function is_debug_enabled(): bool
+function is_parallel_processing_enabled(): bool
 {
-    return defined(DEBUG_CONST) && true === constant(DEBUG_CONST);
+    return false === defined(NO_PARALLEL_PROCESSING) || false === constant(NO_PARALLEL_PROCESSING);
 }


### PR DESCRIPTION
- Instead of dumping the files as they are added to the PHAR in debug mode, the code of the PHAR is
  simply extracted at the end of the compilation process to the debug directory
- A new `--no-parallel` option has been added to the `compile` command to not process the files in
  parallel instead of doing so only in debug mode
- A new `--no-restart` option has been added to the `compile` command to not restart the PHP process
  allow more easily to keep xdebug enabled
- The verbosity is now forced to debug ealier when the debug mode is enabled. This ensures the new
  verbosity set applies to the process restart check