### PR TITLE
Fix the main script inclusion

### DIFF
--- a/bin/box
+++ b/bin/box
@@ -15,9 +15,9 @@ declare(strict_types=1);
 
 namespace KevinGH\Box;
 
-use function file_exists;
 use KevinGH\Box\Console\Application;
 use RuntimeException;
+use function file_exists;
 
 (function (): void {
     if (file_exists($autoload = __DIR__.'/../../../autoload.php')) {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -152,6 +152,10 @@ or directory from a dev dependency, you can do so by adding it via one of the fo
 [`files-bin`][files], [`directories`][directories] or [`directories-bin`][directories].
 
 
+**Warning:** binary files are added _before_ regular files. As a result if a file is found in both regular files and
+binary files, the regular file will take precedence.
+
+
 ### Files (`files` and `files-bin`)
 
 The `files` (`string[]`) setting is a list of files paths relative to [`base-path`][base-path] unless absolute. Each

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 
 namespace KevinGH\Box;
 
+use ErrorException;
+use RuntimeException;
 use function bin2hex;
 use function copy;
 use function defined;
 use function dirname;
-use ErrorException;
 use function random_bytes;
 use function register_shutdown_function;
-use RuntimeException;
 use function substr;
 use function sys_get_temp_dir;
 use function unlink;
@@ -51,13 +51,13 @@ $findPhpScoperFunctions = function (): void {
         }
 
         $pharPath = dirname(substr(__FILE__, 7), 2);
-        define('PHAR_COPY', sys_get_temp_dir().'/phar-'.bin2hex(random_bytes(10)). '.phar');
+        define('PHAR_COPY', sys_get_temp_dir().'/phar-'.bin2hex(random_bytes(10)).'.phar');
 
         copy($pharPath, \PHAR_COPY);
 
-        $autoload = 'phar://'.\PHAR_COPY. '/vendor/humbug/php-scoper/src/functions.php';
+        $autoload = 'phar://'.\PHAR_COPY.'/vendor/humbug/php-scoper/src/functions.php';
 
-        register_shutdown_function(static function () {
+        register_shutdown_function(static function (): void {
             @unlink(\PHAR_COPY);
         });
 

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -1153,7 +1153,7 @@ Box (repo)
 ? Adding binary files
     > No file found
 ? Adding files
-    > 1 file(s)
+    > No file found
 ? Generating new stub
   - Using shebang line: #!/usr/bin/env php
   - Using banner:
@@ -1216,7 +1216,7 @@ Box (repo)
 ? Adding binary files
     > No file found
 ? Adding files
-    > 1 file(s)
+    > No file found
 ? Generating new stub
   - Using shebang line: #!/usr/bin/env php
   - Using banner:
@@ -1278,7 +1278,7 @@ Box (repo)
 ? Adding binary files
     > No file found
 ? Adding files
-    > 1 file(s)
+    > No file found
 ? Generating new stub
   - Using shebang line: #!/usr/bin/env php
   - Using custom banner from file: /path/to/tmp/banner
@@ -1335,7 +1335,7 @@ Box (repo)
 ? Adding binary files
     > No file found
 ? Adding files
-    > 1 file(s)
+    > No file found
 ? Using stub file: /path/to/tmp/stub.php
 ? No compression
 * Done.
@@ -1444,7 +1444,7 @@ Box (repo)
 ? Adding binary files
     > No file found
 ? Adding files
-    > 1 file(s)
+    > No file found
 ? Generating new stub
   - Using shebang line: #!/usr/bin/env php
   - Using banner:
@@ -1509,7 +1509,7 @@ Box (repo)
 ? Adding binary files
     > No file found
 ? Adding files
-    > 1 file(s)
+    > No file found
 ? Generating new stub
   - Using shebang line: #!/usr/bin/env php
   - Using banner:
@@ -1653,7 +1653,7 @@ Box (repo)
 ? Adding binary files
     > No file found
 ? Adding files
-    > 1 file(s)
+    > No file found
 ? Generating new stub
   - No shebang line
   - Using banner:
@@ -1731,7 +1731,7 @@ Box (repo)
 ? Adding binary files
     > No file found
 ? Adding files
-    > 1 file(s)
+    > No file found
 ? Using stub file: /path/to/tmp/stub.php
 ? No compression
 * Done.


### PR DESCRIPTION
Since the main script requires some special processing and is added before the regular and binary
files, it should not be included in the regular or binary files.

This was actually the case when the main script was included via `files`, `files-bin` and `append`
(from `finder` or `finder-bin`). The main script path is now properly excluded in such cases.

Closes #168