### PR TITLE
Start Amp only if PHP-Scoper is used

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -338,7 +338,7 @@ final class Box
             return [$local, $processedContents];
         };
 
-        return is_parallel_processing_enabled()
+        return is_parallel_processing_enabled() && false === ($this->scoper instanceof NullScoper)
             ? wait(parallelMap($files, $processFile))
             : array_map($processFile, $files)
         ;

--- a/tests/BoxTest.php
+++ b/tests/BoxTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace KevinGH\Box;
 
-use Amp\MultiReasonException;
 use Exception;
 use InvalidArgumentException;
 use KevinGH\Box\Compactor\FakeCompactor;
@@ -768,7 +767,7 @@ class BoxTest extends FileSystemTestCase
             $this->box->addFiles(['/nowhere/foo'], false);
 
             $this->fail('Expected exception to be thrown.');
-        } catch (MultiReasonException $exception) {
+        } catch (InvalidArgumentException $exception) {
             $tmpDirs = iterator_to_array(
                 Finder::create()
                     ->directories()
@@ -777,20 +776,20 @@ class BoxTest extends FileSystemTestCase
             );
 
             $boxDir = current(
-                    array_filter(
-                            $tmpDirs,
-                            function (SplFileInfo $fileInfo) use ($boxTmp): bool {
-                                return false === in_array(
-                                            $fileInfo->getRealPath(),
-                                            [realpath($boxTmp), realpath($this->tmp)],
-                            true
-                                    );
-                            }
+                array_filter(
+                    $tmpDirs,
+                    function (SplFileInfo $fileInfo) use ($boxTmp): bool {
+                        return false === in_array(
+                            $fileInfo->getRealPath(),
+                            [realpath($boxTmp), realpath($this->tmp)],
+                        true
+                        );
+                    }
                 )
             );
 
             $this->assertFalse(
-                    $boxDir,
+                $boxDir,
                 sprintf(
                         'Did not expect to find the directory "%s".',
                     $boxDir


### PR DESCRIPTION
Starting Amp has an overhead and increase the likelyhood of rising an issue due to how Amp works. As
a result, it is better to not have to start it unless necessary. So far the current compactors are
fast enough to not require parallel processing, the build from Box without PHP-Scoper goes from 5s
with parallel processing to 3s without.

Closes #135