### PR TITLE
Fix PHAR minimal requirements

### DIFF
--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -432,7 +432,7 @@ EOF
             'Adding requirements checker'
         );
 
-        $checkFiles = RequirementsDumper::dump($config->getComposerLockDecodedContents());
+        $checkFiles = RequirementsDumper::dump($config->getComposerLockDecodedContents(), null !== $config->getCompressionAlgorithm());
 
         foreach ($checkFiles as $fileWithContents) {
             [$file, $contents] = $fileWithContents;

--- a/src/RequirementChecker/AppRequirementsFactory.php
+++ b/src/RequirementChecker/AppRequirementsFactory.php
@@ -33,11 +33,12 @@ final class AppRequirementsFactory
      *
      * @return array Serialized configured requirements
      */
-    public static function create(array $composerLockDecodedContents): array
+    public static function create(array $composerLockDecodedContents, bool $compressed): array
     {
         return self::configureExtensionRequirements(
             self::configurePhpVersionRequirements([], $composerLockDecodedContents),
-            $composerLockDecodedContents
+            $composerLockDecodedContents,
+            $compressed
         );
     }
 
@@ -88,9 +89,9 @@ final class AppRequirementsFactory
         return $requirements;
     }
 
-    private static function configureExtensionRequirements(array $requirements, array $composerLockContents): array
+    private static function configureExtensionRequirements(array $requirements, array $composerLockContents, bool $compressed): array
     {
-        $extensionRequirements = self::collectExtensionRequirements($composerLockContents);
+        $extensionRequirements = self::collectExtensionRequirements($composerLockContents, $compressed);
 
         foreach ($extensionRequirements as $extension => $packages) {
             foreach ($packages as $package) {
@@ -135,10 +136,14 @@ final class AppRequirementsFactory
      *
      * @return array Associative array containing the list of extensions required
      */
-    private static function collectExtensionRequirements(array $composerLockContents): array
+    private static function collectExtensionRequirements(array $composerLockContents, bool $compressed): array
     {
         $requirements = [];
         $polyfills = [];
+
+        if ($compressed) {
+            $requirements['zip'] = [self::SELF_PACKAGE];
+        }
 
         $platform = $composerLockContents['platform'] ?? [];
 

--- a/src/RequirementChecker/RequirementsDumper.php
+++ b/src/RequirementChecker/RequirementsDumper.php
@@ -57,10 +57,10 @@ PHP;
     /**
      * @return string[][]
      */
-    public static function dump(array $composerLockDecodedContents): array
+    public static function dump(array $composerLockDecodedContents, bool $compressed): array
     {
         $filesWithContents = [
-            self::dumpRequirementsConfig($composerLockDecodedContents),
+            self::dumpRequirementsConfig($composerLockDecodedContents, $compressed),
             [self::CHECK_FILE_NAME, self::REQUIREMENTS_CHECKER_TEMPLATE],
         ];
 
@@ -80,9 +80,9 @@ PHP;
         return $filesWithContents;
     }
 
-    private static function dumpRequirementsConfig(array $composerLockDecodedContents): array
+    private static function dumpRequirementsConfig(array $composerLockDecodedContents, bool $compressed): array
     {
-        $config = AppRequirementsFactory::create($composerLockDecodedContents);
+        $config = AppRequirementsFactory::create($composerLockDecodedContents, $compressed);
 
         return [
             '.requirements.php',


### PR DESCRIPTION
When a PHAR is compressed, it also requires the PHP extension `zip`.

Closes #164