### PR TITLE
Apply the blacklist to the retrieved directories from the composer.json

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -64,7 +64,6 @@ $config = PhpCsFixer\Config::create()
         'phpdoc_order' => true,
         'phpdoc_types_order' => true,
         'semicolon_after_instruction' => true,
-        'single_line_comment_style' => true,
         'strict_param' => true,
         'yoda_style' => true,
     ])

--- a/bin/box
+++ b/bin/box
@@ -16,9 +16,9 @@ declare(strict_types=1);
 namespace KevinGH\Box;
 
 use KevinGH\Box\Console\Application;
+use RuntimeException;
 use const PHP_EOL;
 use const PHP_SAPI;
-use RuntimeException;
 use function file_exists;
 
 if (PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg') {

--- a/requirement-checker/src/Checker.php
+++ b/requirement-checker/src/Checker.php
@@ -14,8 +14,9 @@ namespace KevinGH\RequirementChecker;
 
 /**
  * @private
+ *
  * @see bin/requirements-checker.php
- * @package symfony/requirements-checker
+ *
  * @license MIT (c) Fabien Potencier <fabien@symfony.com>
  */
 final class Checker

--- a/requirement-checker/src/IO.php
+++ b/requirement-checker/src/IO.php
@@ -163,6 +163,7 @@ final class IO
      * @return bool true if the stream supports colorization, false otherwise
      *
      * @see \Symfony\Component\Console\Output\StreamOutput
+     *
      * @license MIT (c) Fabien Potencier <fabien@symfony.com>
      */
     private function checkColorSupport()

--- a/requirement-checker/src/Requirement.php
+++ b/requirement-checker/src/Requirement.php
@@ -14,8 +14,9 @@ namespace KevinGH\RequirementChecker;
 
 /**
  * @private
+ *
  * @see \Symfony\Requirements\Requirement
- * @package symfony/requirements-checker
+ *
  * @license MIT (c) Fabien Potencier <fabien@symfony.com>
  */
 final class Requirement

--- a/requirement-checker/src/RequirementCollection.php
+++ b/requirement-checker/src/RequirementCollection.php
@@ -19,8 +19,9 @@ use Traversable;
 
 /**
  * @private
+ *
  * @see \Symfony\Requirements\RequirementCollection
- * @package symfony/requirements-checker
+ *
  * @license MIT (c) Fabien Potencier <fabien@symfony.com>
  */
 final class RequirementCollection implements IteratorAggregate, Countable

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace KevinGH\Box;
 
+use function array_diff;
+use function array_diff_key;
 use Assert\Assertion;
 use Closure;
 use DateTimeImmutable;
@@ -904,10 +906,8 @@ BANNER;
         array $filesToAppend,
         array $excludedPaths
     ): array {
-        $excludedPaths = array_flip($excludedPaths);
-
         $toString = function ($file): string {
-            // @param string|SplFileInfo $file
+            /** @param string|SplFileInfo $file */
             return (string) $file;
         };
 
@@ -997,7 +997,7 @@ BANNER;
 
         if (array_key_exists('classmap', $autoload)) {
             foreach ($autoload['classmap'] as $path) {
-                // @var string $path
+                /** @var string $path */
                 $paths[] = $path;
             }
         }
@@ -1012,11 +1012,7 @@ BANNER;
         if (array_key_exists('files', $autoload)) {
             foreach ($autoload['files'] as $path) {
                 /** @var string $path */
-                $path = $normalizePath($path);
-
-                if (false === array_key_exists($path, $excludedPaths)) {
-                    $filesToAppend[] = $path;
-                }
+                $filesToAppend[] = $normalizePath($path);
             }
         }
 
@@ -1033,9 +1029,14 @@ BANNER;
             }
         }
 
-        return [
+        [$files, $directories] = [
             array_unique($files),
             array_unique($directories),
+        ];
+
+        return [
+            array_diff($files, $excludedPaths),
+            array_diff($directories, $excludedPaths),
         ];
     }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 
 namespace KevinGH\Box;
 
-use function array_diff;
-use function array_diff_key;
 use Assert\Assertion;
 use Closure;
 use DateTimeImmutable;
@@ -36,8 +34,8 @@ use stdClass;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
 use function array_column;
+use function array_diff;
 use function array_filter;
-use function array_flip;
 use function array_key_exists;
 use function array_map;
 use function array_merge;
@@ -907,7 +905,7 @@ BANNER;
         array $excludedPaths
     ): array {
         $toString = function ($file): string {
-            /** @param string|SplFileInfo $file */
+            // @param string|SplFileInfo $file
             return (string) $file;
         };
 
@@ -997,7 +995,7 @@ BANNER;
 
         if (array_key_exists('classmap', $autoload)) {
             foreach ($autoload['classmap'] as $path) {
-                /** @var string $path */
+                // @var string $path
                 $paths[] = $path;
             }
         }
@@ -1011,7 +1009,7 @@ BANNER;
 
         if (array_key_exists('files', $autoload)) {
             foreach ($autoload['files'] as $path) {
-                /** @var string $path */
+                // @var string $path
                 $filesToAppend[] = $normalizePath($path);
             }
         }

--- a/tests/ConfigurationFileNoConfigTest.php
+++ b/tests/ConfigurationFileNoConfigTest.php
@@ -180,6 +180,10 @@ JSON
         touch('DEV_PSR0_0/file0');
         touch('DEV_PSR0_0/file1');
 
+        mkdir('BLACKLISTED_CLASSMAP_DIR');
+        touch('BLACKLISTED_CLASSMAP_DIR/file0');
+        touch('BLACKLISTED_CLASSMAP_DIR/file1');
+
         mkdir('CLASSMAP_DIR');
         touch('CLASSMAP_DIR/file0');
         touch('CLASSMAP_DIR/file1');
@@ -202,7 +206,10 @@ JSON
             "Acme\\": "PSR0_0",
             "Bar\\": ["PSR0_1", "PSR0_2"]
         },
-        "classmap": ["CLASSMAP_DIR"]
+        "classmap": [
+            "BLACKLISTED_CLASSMAP_DIR",
+            "CLASSMAP_DIR"
+        ]
     },
     "autoload-dev": {
         "files": ["file2"],
@@ -221,6 +228,7 @@ JSON
         $this->setConfig([
             'blacklist' => [
                 'file1',
+                'BLACKLISTED_CLASSMAP_DIR',
             ],
         ]);
 


### PR DESCRIPTION
If the files/directories directly collected from the `composer.json` are not excluded, the finder
blacklist will not be able to operate on it.

This was already accounted for the blacklisted files but was not applied to the directories.