### PR TITLE
Refactor the way files are added to the PHAR

### DIFF
--- a/src/Console/Command/Build.php
+++ b/src/Console/Command/Build.php
@@ -17,8 +17,8 @@ namespace KevinGH\Box\Console\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use const E_USER_DEPRECATED;
 use function trigger_error;
+use const E_USER_DEPRECATED;
 
 /**
  * @deprecated

--- a/src/PhpSettingsHandler.php
+++ b/src/PhpSettingsHandler.php
@@ -17,11 +17,11 @@ namespace KevinGH\Box;
 use Composer\XdebugHandler\XdebugHandler;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
-use const FILE_APPEND;
-use const PHP_EOL;
 use function file_put_contents;
 use function ini_get;
 use function sprintf;
+use const FILE_APPEND;
+use const PHP_EOL;
 
 /**
  * @private

--- a/tests/ConfigurationFileTest.php
+++ b/tests/ConfigurationFileTest.php
@@ -17,12 +17,12 @@ namespace KevinGH\Box;
 use Generator;
 use InvalidArgumentException;
 use KevinGH\Box\Json\JsonValidationException;
-use const DIRECTORY_SEPARATOR;
 use function file_put_contents;
 use function KevinGH\Box\FileSystem\dump_file;
 use function KevinGH\Box\FileSystem\make_path_absolute;
 use function KevinGH\Box\FileSystem\rename;
 use function KevinGH\Box\FileSystem\symlink;
+use const DIRECTORY_SEPARATOR;
 
 /**
  * @covers \KevinGH\Box\Configuration

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -25,10 +25,10 @@ use KevinGH\Box\Json\JsonValidationException;
 use Phar;
 use Seld\JsonLint\ParsingException;
 use stdClass;
-use const DIRECTORY_SEPARATOR;
 use function file_put_contents;
 use function KevinGH\Box\FileSystem\dump_file;
 use function KevinGH\Box\FileSystem\rename;
+use const DIRECTORY_SEPARATOR;
 
 /**
  * @covers \KevinGH\Box\Configuration

--- a/tests/ConfigurationTestCase.php
+++ b/tests/ConfigurationTestCase.php
@@ -17,10 +17,10 @@ namespace KevinGH\Box;
 use KevinGH\Box\Console\ConfigurationHelper;
 use KevinGH\Box\Test\FileSystemTestCase;
 use stdClass;
-use const DIRECTORY_SEPARATOR;
 use function file_put_contents;
 use function KevinGH\Box\FileSystem\make_path_absolute;
 use function natcasesort;
+use const DIRECTORY_SEPARATOR;
 
 abstract class ConfigurationTestCase extends FileSystemTestCase
 {

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -1934,6 +1934,12 @@ OUTPUT;
         );
 
         $display = preg_replace(
+            '/You can inspect the generated PHAR( | *\n *\/\/ *)with( | *\n *\/\/ *)the( | *\n *\/\/ *)"info"( | *\n *\/\/ *)command/',
+            'You can inspect the generated PHAR with the "info" command',
+            $display
+        );
+
+        $display = preg_replace(
             '/\/\/ PHAR size: \d+\.\d{2}K?B/',
             '// PHAR size: 100B',
             $display

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -36,13 +36,10 @@ use function preg_replace;
 use function putenv;
 use function sort;
 
-///**
-// * @covers \KevinGH\Box\Console\Command\Compile
-// * @runTestsInSeparateProcesses This is necessary as instantiating a PHAR in memory may load/autoload some stuff which
-// *                              can create undesirable side-effects.
-// */
 /**
- * @coversNothing
+ * @covers \KevinGH\Box\Console\Command\Compile
+ * @runTestsInSeparateProcesses This is necessary as instantiating a PHAR in memory may load/autoload some stuff which
+ *                              can create undesirable side-effects.
  */
 class CompileTest extends CommandTestCase
 {
@@ -130,6 +127,8 @@ Building the PHAR "/path/to/tmp/test.phar"
 Private key passphrase:
 ? Setting file permissions to 0755
 * Done.
+
+ // You can inspect the generated PHAR with the "info" command.
 
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
@@ -335,6 +334,8 @@ Building the PHAR "/path/to/tmp/index.phar"
 ? No compression
 * Done.
 
+ // You can inspect the generated PHAR with the "info" command.
+
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
@@ -501,6 +502,8 @@ Building the PHAR "/path/to/tmp/test.phar"
 ? No compression
 ? Setting file permissions to 0755
 * Done.
+
+ // You can inspect the generated PHAR with the "info" command.
 
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
@@ -737,6 +740,8 @@ Private key passphrase:
 ? Setting file permissions to 0755
 * Done.
 
+ // You can inspect the generated PHAR with the "info" command.
+
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
@@ -833,6 +838,8 @@ Box (repo)
 Private key passphrase:
 ? Setting file permissions to 0755
 * Done.
+
+ // You can inspect the generated PHAR with the "info" command.
 
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
@@ -1166,6 +1173,8 @@ Box (repo)
 ? No compression
 * Done.
 
+ // You can inspect the generated PHAR with the "info" command.
+
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
@@ -1229,6 +1238,8 @@ Box (repo)
 ? No compression
 * Done.
 
+ // You can inspect the generated PHAR with the "info" command.
+
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
@@ -1288,6 +1299,8 @@ Box (repo)
 ? No compression
 * Done.
 
+ // You can inspect the generated PHAR with the "info" command.
+
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
@@ -1342,6 +1355,8 @@ Box (repo)
 ? Using stub file: /path/to/tmp/stub.php
 ? No compression
 * Done.
+
+ // You can inspect the generated PHAR with the "info" command.
 
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
@@ -1403,6 +1418,8 @@ Box (repo)
 ? No compression
 * Done.
 
+ // You can inspect the generated PHAR with the "info" command.
+
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
@@ -1456,6 +1473,8 @@ Box (repo)
     > @link https://github.com/humbug/box
 ? Compressing with the algorithm "GZ"
 * Done.
+
+ // You can inspect the generated PHAR with the "info" command.
 
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
@@ -1521,6 +1540,8 @@ Box (repo)
     > @link https://github.com/humbug/box
 ? No compression
 * Done.
+
+ // You can inspect the generated PHAR with the "info" command.
 
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
@@ -1666,6 +1687,8 @@ Box (repo)
 ? Compressing with the algorithm "GZ"
 * Done.
 
+ // You can inspect the generated PHAR with the "info" command.
+
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
 
@@ -1738,6 +1761,8 @@ Box (repo)
 ? Using stub file: /path/to/tmp/stub.php
 ? No compression
 * Done.
+
+ // You can inspect the generated PHAR with the "info" command.
 
  // PHAR size: 100B
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s


### PR DESCRIPTION
No longer rely on the exposed PHAR by the Box class and instead introduce a new API. The new API is meant to keep all the added files in memory and add them to the PHAR in one shot at the very end.
This will make it easier to decide whether or not the autoload should be dumped and no longer worry about the order in which the files are added regarding the autoload.