### PR TITLE
Allow dumping requirements from the composer.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ if you are using a PHAR of an application compatible with PHP 7.2 in PHP 7.0 or 
 required extension, it will simply break with a non-friendly error.
 
 By default, when building your PHAR with Box, Box will look up for the PHP versions and extensions required to execute your
-application according to your `composer.json` and `composer.lock` files and ship a micro
-[requirements checker][check-requirements] which will be executed when starting your PHAR.
+application according to your `composer.json` and `composer.lock` files and ship a micro (>300KB uncompressed and >40KB
+compressed) [requirements checker][check-requirements] which will be executed when starting your PHAR.
 
 The following are screenshots of the output when an error occurs (left) in a non-quiet verbosity and when all requirements
 are passing on the right in debug verbosity.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -130,8 +130,15 @@ When running the PHAR, before running the actual application, the PHAR will chec
 that the extension `iconv` is loaded. If those requirements are not met, then a user friendly error message will be given
 to the user.
 
-This check will work for PHP 5.3+ and requires the existence of the `composer.lock` file. If no `composer.lock` file is found
-then the requirements check will not be added to the PHAR.
+This check will work for PHP 5.3+ and requires the existence of the `composer.json` or `composer.lock` file. If neither of
+those files are found then the requirements check will not be added to the PHAR.
+
+Be wary that when a `composer.lock` file is found, it will be taken as the source of truth for establishing the requirements
+regardless of the content of the `composer.json`.
+
+If a `composer.json` is found without a `composer.lock`, the it will be taken as the source of truth for establishing the
+requirements regardless of whether there is no `composer.lock` because there is no dependencies or because it has been
+removed.
 
 
 ## Including files

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -305,6 +305,7 @@ BANNER;
 
         $checkRequirements = self::retrieveCheckRequirements(
             $raw,
+            null !== $composerJson[0],
             null !== $composerLock[0],
             $isStubGenerated
         );
@@ -1768,11 +1769,11 @@ BANNER;
         return null === $stubPath && (false === isset($raw->stub) || false !== $raw->stub);
     }
 
-    private static function retrieveCheckRequirements(stdClass $raw, bool $hasComposerLock, bool $generateStub): bool
+    private static function retrieveCheckRequirements(stdClass $raw, bool $hasComposerJson, bool $hasComposerLock, bool $generateStub): bool
     {
         // TODO: emit warning when stub is not generated and check requirements is explicitly set to true
         // TODO: emit warning when no composer lock is found but check requirements is explicitely set to true
-        if (false === $hasComposerLock) {
+        if (false === $hasComposerJson && false === $hasComposerLock) {
             return false;
         }
 

--- a/src/Console/Command/Build.php
+++ b/src/Console/Command/Build.php
@@ -17,8 +17,8 @@ namespace KevinGH\Box\Console\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use const E_USER_DEPRECATED;
 use function trigger_error;
+use const E_USER_DEPRECATED;
 
 /**
  * @deprecated

--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -38,9 +38,6 @@ use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
-use const DATE_ATOM;
-use const POSIX_RLIMIT_INFINITY;
-use const POSIX_RLIMIT_NOFILE;
 use function array_shift;
 use function count;
 use function decoct;
@@ -63,6 +60,9 @@ use function strlen;
 use function strtolower;
 use function substr;
 use function trim;
+use const DATE_ATOM;
+use const POSIX_RLIMIT_INFINITY;
+use const POSIX_RLIMIT_NOFILE;
 
 /**
  * @final
@@ -498,7 +498,8 @@ EOF
         );
 
         $checkFiles = RequirementsDumper::dump(
-            $config->getComposerLockDecodedContents(),
+            $config->getComposerJsonDecodedContents() ?? [],
+            $config->getComposerLockDecodedContents() ?? [],
             null !== $config->getCompressionAlgorithm()
         );
 

--- a/src/RequirementChecker/AppRequirementsFactory.php
+++ b/src/RequirementChecker/AppRequirementsFactory.php
@@ -181,14 +181,14 @@ final class AppRequirementsFactory
         }
 
         [$polyfills, $requirements] = [] === $composerLockContents
-            ? self::collectComposerJsonExtensionRequirements($composerJsonContents, $matches, $polyfills, $requirements)
-            : self::collectComposerLockExtensionRequirements($composerLockContents, $matches, $polyfills, $requirements)
+            ? self::collectComposerJsonExtensionRequirements($composerJsonContents, $polyfills, $requirements)
+            : self::collectComposerLockExtensionRequirements($composerLockContents, $polyfills, $requirements)
         ;
 
         return array_diff_key($requirements, $polyfills);
     }
 
-    private static function collectComposerJsonExtensionRequirements(array $composerJsonContents, $matches, $polyfills, $requirements): array
+    private static function collectComposerJsonExtensionRequirements(array $composerJsonContents, $polyfills, $requirements): array
     {
         $packages = $composerJsonContents['require'] ?? [];
 
@@ -223,7 +223,7 @@ final class AppRequirementsFactory
         return [$polyfills, $requirements];
     }
 
-    private static function collectComposerLockExtensionRequirements(array $composerLockContents, $matches, $polyfills, $requirements): array
+    private static function collectComposerLockExtensionRequirements(array $composerLockContents, $polyfills, $requirements): array
     {
         $packages = $composerLockContents['packages'] ?? [];
 

--- a/src/RequirementChecker/AppRequirementsFactory.php
+++ b/src/RequirementChecker/AppRequirementsFactory.php
@@ -29,39 +29,62 @@ final class AppRequirementsFactory
     private const SELF_PACKAGE = '__APPLICATION__';
 
     /**
+     * @param array $composerJsonDecodedContents Decoded JSON contents of the `composer.json` file
      * @param array $composerLockDecodedContents Decoded JSON contents of the `composer.lock` file
      *
      * @return array Serialized configured requirements
      */
-    public static function create(array $composerLockDecodedContents, bool $compressed): array
+    public static function create(array $composerJsonDecodedContents, array $composerLockDecodedContents, bool $compressed): array
     {
         return self::configureExtensionRequirements(
-            self::configurePhpVersionRequirements([], $composerLockDecodedContents),
+            self::retrievePhpVersionRequirements([], $composerJsonDecodedContents, $composerLockDecodedContents),
+            $composerJsonDecodedContents,
             $composerLockDecodedContents,
             $compressed
         );
     }
 
-    private static function configurePhpVersionRequirements(array $requirements, array $composerLockContents): array
-    {
-        if (isset($composerLockContents['platform']['php'])) {
-            $requiredPhpVersion = $composerLockContents['platform']['php'];
-
-            $requirements[] = [
-                self::generatePhpCheckStatement((string) $requiredPhpVersion),
-                sprintf(
-                    'The application requires the version "%s" or greater.',
-                    $requiredPhpVersion
-                ),
-                sprintf(
-                    'The application requires the version "%s" or greater.',
-                    $requiredPhpVersion
-                ),
-            ];
-
-            return $requirements; // No need to check the packages requirements: the application platform config is the authority here
+    private static function retrievePhpVersionRequirements(
+        array $requirements,
+        array $composerJsonContents,
+        array $composerLockContents
+    ): array {
+        if (([] === $composerLockContents && isset($composerJsonContents['require']['php']))
+            || isset($composerLockContents['platform']['php'])
+        ) {
+            // No need to check the packages requirements: the application platform config is the authority here
+            return self::retrievePlatformPhpRequirement($requirements, $composerJsonContents, $composerLockContents);
         }
 
+        return self::retrievePackagesPhpRequirement($requirements, $composerLockContents);
+    }
+
+    private static function retrievePlatformPhpRequirement(
+        array $requirements,
+        array $composerJsonContents,
+        array $composerLockContents
+    ): array {
+        $requiredPhpVersion = [] === $composerLockContents
+            ? $composerJsonContents['require']['php']
+            : $composerLockContents['platform']['php'];
+
+        $requirements[] = [
+            self::generatePhpCheckStatement((string) $requiredPhpVersion),
+            sprintf(
+                'The application requires the version "%s" or greater.',
+                $requiredPhpVersion
+            ),
+            sprintf(
+                'The application requires the version "%s" or greater.',
+                $requiredPhpVersion
+            ),
+        ];
+
+        return $requirements;
+    }
+
+    private static function retrievePackagesPhpRequirement(array $requirements, array $composerLockContents): array
+    {
         $packages = $composerLockContents['packages'] ?? [];
 
         foreach ($packages as $packageInfo) {
@@ -89,9 +112,13 @@ final class AppRequirementsFactory
         return $requirements;
     }
 
-    private static function configureExtensionRequirements(array $requirements, array $composerLockContents, bool $compressed): array
-    {
-        $extensionRequirements = self::collectExtensionRequirements($composerLockContents, $compressed);
+    private static function configureExtensionRequirements(
+        array $requirements,
+        array $composerJsonContents,
+        array $composerLockContents,
+        bool $compressed
+    ): array {
+        $extensionRequirements = self::collectExtensionRequirements($composerJsonContents, $composerLockContents, $compressed);
 
         foreach ($extensionRequirements as $extension => $packages) {
             foreach ($packages as $package) {
@@ -132,11 +159,9 @@ final class AppRequirementsFactory
      * Collects the extension required. It also accounts for the polyfills, i.e. if the polyfill `symfony/polyfill-mbstring` is provided
      * then the extension `ext-mbstring` will not be required.
      *
-     * @param array $composerLockContents
-     *
      * @return array Associative array containing the list of extensions required
      */
-    private static function collectExtensionRequirements(array $composerLockContents, bool $compressed): array
+    private static function collectExtensionRequirements(array $composerJsonContents, array $composerLockContents, bool $compressed): array
     {
         $requirements = [];
         $polyfills = [];
@@ -155,6 +180,51 @@ final class AppRequirementsFactory
             }
         }
 
+        [$polyfills, $requirements] = [] === $composerLockContents
+            ? self::collectComposerJsonExtensionRequirements($composerJsonContents, $matches, $polyfills, $requirements)
+            : self::collectComposerLockExtensionRequirements($composerLockContents, $matches, $polyfills, $requirements)
+        ;
+
+        return array_diff_key($requirements, $polyfills);
+    }
+
+    private static function collectComposerJsonExtensionRequirements(array $composerJsonContents, $matches, $polyfills, $requirements): array
+    {
+        $packages = $composerJsonContents['require'] ?? [];
+
+        foreach ($packages as $packageName => $constraint) {
+            if (1 === preg_match('/symfony\/polyfill-(?<extension>.+)/', $packageName, $matches)) {
+                $extension = $matches['extension'];
+
+                if ('php' !== substr($extension, 0, 3)) {
+                    $polyfills[$extension] = true;
+
+                    continue;
+                }
+            }
+
+            if ('paragonie/sodium_compat' === $packageName) {
+                $polyfills['libsodium'] = true;
+
+                continue;
+            }
+
+            if ('phpseclib/mcrypt_compat' === $packageName) {
+                $polyfills['mcrypt'] = true;
+
+                continue;
+            }
+
+            if ('php' !== $packageName && preg_match('/^ext-(?<extension>.+)$/', $packageName, $matches)) {
+                $requirements[$matches['extension']] = [self::SELF_PACKAGE];
+            }
+        }
+
+        return [$polyfills, $requirements];
+    }
+
+    private static function collectComposerLockExtensionRequirements(array $composerLockContents, $matches, $polyfills, $requirements): array
+    {
         $packages = $composerLockContents['packages'] ?? [];
 
         foreach ($packages as $packageInfo) {
@@ -189,7 +259,7 @@ final class AppRequirementsFactory
             }
         }
 
-        return array_diff_key($requirements, $polyfills);
+        return [$polyfills, $requirements];
     }
 
     private static function generatePhpCheckStatement(string $requiredPhpVersion): string

--- a/src/RequirementChecker/RequirementsDumper.php
+++ b/src/RequirementChecker/RequirementsDumper.php
@@ -57,10 +57,10 @@ PHP;
     /**
      * @return string[][]
      */
-    public static function dump(array $composerLockDecodedContents, bool $compressed): array
+    public static function dump(array $composerJsonDecodedContents, array $composerLockDecodedContents, bool $compressed): array
     {
         $filesWithContents = [
-            self::dumpRequirementsConfig($composerLockDecodedContents, $compressed),
+            self::dumpRequirementsConfig($composerJsonDecodedContents, $composerLockDecodedContents, $compressed),
             [self::CHECK_FILE_NAME, self::REQUIREMENTS_CHECKER_TEMPLATE],
         ];
 
@@ -80,9 +80,12 @@ PHP;
         return $filesWithContents;
     }
 
-    private static function dumpRequirementsConfig(array $composerLockDecodedContents, bool $compressed): array
-    {
-        $config = AppRequirementsFactory::create($composerLockDecodedContents, $compressed);
+    private static function dumpRequirementsConfig(
+        array $composerJsonDecodedContents,
+        array $composerLockDecodedContents,
+        bool $compressed
+    ): array {
+        $config = AppRequirementsFactory::create($composerJsonDecodedContents, $composerLockDecodedContents, $compressed);
 
         return [
             '.requirements.php',

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -28,6 +28,7 @@ use stdClass;
 use const DIRECTORY_SEPARATOR;
 use function file_put_contents;
 use function KevinGH\Box\FileSystem\dump_file;
+use function KevinGH\Box\FileSystem\remove;
 use function KevinGH\Box\FileSystem\rename;
 
 /**
@@ -288,7 +289,7 @@ EOF
         }
     }
 
-    public function test_the_autoloader_is_dumped_by_default_if_a_composer_json_file_is_found()
+    public function test_the_autoloader_is_dumped_by_default_if_a_composer_json_file_is_found(): void
     {
         $this->assertFalse($this->config->dumpAutoload());
         $this->assertFalse($this->getNoFileConfig()->dumpAutoload());
@@ -309,7 +310,7 @@ EOF
         $this->assertTrue($this->config->dumpAutoload());
     }
 
-    public function test_the_autoloader_is_can_be_configured()
+    public function test_the_autoloader_is_can_be_configured(): void
     {
         file_put_contents('composer.json', '{}');
 
@@ -328,7 +329,7 @@ EOF
         $this->assertTrue($this->getNoFileConfig()->dumpAutoload());
     }
 
-    public function test_the_autoloader_cannot_be_dumped_if_no_composer_json_file_is_found()
+    public function test_the_autoloader_cannot_be_dumped_if_no_composer_json_file_is_found(): void
     {
         $this->setConfig([
             'dump-autoload' => true,
@@ -1232,14 +1233,23 @@ COMMENT;
         $this->assertFalse($this->config->isPrivateKeyPrompt());
     }
 
-    public function test_the_requirement_checker_is_enabled_by_default(): void
+    public function test_the_requirement_checker_is_enabled_by_default_if_a_composer_lock_or_json_file_is_found(): void
     {
         $this->assertFalse($this->config->checkRequirements());
-    }
 
-    public function test_the_requirement_checker_is_enabled_by_default_if_a_composer_lock_file_is_found(): void
-    {
         file_put_contents('composer.lock', '{}');
+
+        $this->reloadConfig();
+
+        $this->assertTrue($this->config->checkRequirements());
+
+        file_put_contents('composer.json', '{}');
+
+        $this->reloadConfig();
+
+        $this->assertTrue($this->config->checkRequirements());
+
+        remove('composer.lock');
 
         $this->reloadConfig();
 

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -321,6 +321,7 @@ Box (repo)
 Building the PHAR "/path/to/tmp/index.phar"
 ? No compactor to register
 ? Adding main file: /path/to/tmp/index.php
+? Adding requirements checker
 ? Adding binary files
     > No file found
 ? Adding files
@@ -373,6 +374,8 @@ OUTPUT;
 
 Phar::mapPhar('box-auto-generated-alias-__uniqid__.phar');
 
+require 'phar://box-auto-generated-alias-__uniqid__.phar/.box/check_requirements.php';
+
 require 'phar://box-auto-generated-alias-__uniqid__.phar/index.php';
 
 __HALT_COMPILER(); ?>
@@ -387,6 +390,42 @@ PHP;
         );
 
         $expectedFiles = [
+            '/.box/',
+            '/.box/.requirements.php',
+            '/.box/bin/',
+            '/.box/bin/check-requirements.php',
+            '/.box/check_requirements.php',
+            '/.box/composer.json',
+            '/.box/composer.lock',
+            '/.box/src/',
+            '/.box/src/Checker.php',
+            '/.box/src/IO.php',
+            '/.box/src/Printer.php',
+            '/.box/src/Requirement.php',
+            '/.box/src/RequirementCollection.php',
+            '/.box/src/Terminal.php',
+            '/.box/vendor/',
+            '/.box/vendor/autoload.php',
+            '/.box/vendor/composer/',
+            '/.box/vendor/composer/ClassLoader.php',
+            '/.box/vendor/composer/LICENSE',
+            '/.box/vendor/composer/autoload_classmap.php',
+            '/.box/vendor/composer/autoload_namespaces.php',
+            '/.box/vendor/composer/autoload_psr4.php',
+            '/.box/vendor/composer/autoload_real.php',
+            '/.box/vendor/composer/autoload_static.php',
+            '/.box/vendor/composer/installed.json',
+            '/.box/vendor/composer/semver/',
+            '/.box/vendor/composer/semver/src/',
+            '/.box/vendor/composer/semver/src/Comparator.php',
+            '/.box/vendor/composer/semver/src/Constraint/',
+            '/.box/vendor/composer/semver/src/Constraint/AbstractConstraint.php',
+            '/.box/vendor/composer/semver/src/Constraint/Constraint.php',
+            '/.box/vendor/composer/semver/src/Constraint/ConstraintInterface.php',
+            '/.box/vendor/composer/semver/src/Constraint/EmptyConstraint.php',
+            '/.box/vendor/composer/semver/src/Constraint/MultiConstraint.php',
+            '/.box/vendor/composer/semver/src/Semver.php',
+            '/.box/vendor/composer/semver/src/VersionParser.php',
             '/bootstrap.php',
             '/composer.json',
             '/index.php',
@@ -440,6 +479,7 @@ PHP;
             json_encode(
                 [
                     'alias' => 'alias-test.phar',
+                    'check-requirements' => false,
                     'chmod' => '0755',
                     'compactors' => [Php::class],
                     'directories' => ['a'],
@@ -592,6 +632,7 @@ PHP;
             'box.json',
             json_encode(
                 [
+                    'check-requirements' => false,
                     'chmod' => '0755',
                     'compactors' => [Php::class],
                     'directories' => ['a'],
@@ -722,6 +763,7 @@ Box (repo)
 ? Mapping paths
   - a/deep/test/directory > sub
 ? Adding main file: /path/to/tmp/run.php
+? Adding requirements checker
 ? Adding binary files
     > 1 file(s)
 ? Adding files
@@ -820,6 +862,7 @@ Box (repo)
 ? Mapping paths
   - a/deep/test/directory > sub
 ? Adding main file: /path/to/tmp/run.php
+? Adding requirements checker
 ? Adding binary files
     > 1 file(s)
 ? Adding files

--- a/tests/PhpScoper/NullScoperTest.php
+++ b/tests/PhpScoper/NullScoperTest.php
@@ -17,7 +17,7 @@ namespace KevinGH\Box\PhpScoper;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @coversNothing
+ * @covers \KevinGH\Box\PhpScoper\NullScoper
  */
 class NullScoperTest extends TestCase
 {

--- a/tests/RequirementChecker/AppRequirementsFactoryTest.php
+++ b/tests/RequirementChecker/AppRequirementsFactoryTest.php
@@ -18,29 +18,66 @@ use PHPUnit\Framework\TestCase;
 use function json_decode;
 
 /**
- * @coversNothing
+ * @covers \KevinGH\Box\RequirementChecker\AppRequirementsFactory
  */
 class AppRequirementsFactoryTest extends TestCase
 {
     /**
      * @dataProvider provideLockContents
      */
-    public function test_it_can_generate_and_serialized_requirements_from_a_composer_lock_file(string $composerLockContents, bool $compressed, array $expected): void
-    {
-        $actual = AppRequirementsFactory::create(json_decode($composerLockContents, true), $compressed);
+    public function test_it_can_generate_and_serialized_requirements_from_a_composer_lock_file(
+        ?string $composerJsonContents,
+        ?string $composerLockContents,
+        bool $compressed,
+        array $expected
+    ): void {
+        $actual = AppRequirementsFactory::create(
+            null === $composerJsonContents ? [] : json_decode($composerJsonContents, true),
+            null === $composerLockContents ? [] : json_decode($composerLockContents, true),
+            $compressed
+        );
 
         $this->assertSame($expected, $actual);
     }
 
     public function provideLockContents()
     {
+        yield 'empty json file' => [
+            '{}',
+            null,
+            false,
+            [],
+        ];
+
         yield 'empty lock file' => [
+            null,
             '{}',
             false,
             [],
         ];
 
+        yield 'empty json & lock file' => [
+            '{}',
+            '{}',
+            false,
+            [],
+        ];
+
+        yield 'empty json file (compressed PHAR)' => [
+            '{}',
+            null,
+            true,
+            [
+                [
+                    "return \\extension_loaded('zip');",
+                    'The application requires the extension "zip". Enable it or install a polyfill.',
+                    'The application requires the extension "zip".',
+                ],
+            ],
+        ];
+
         yield 'empty lock file (compressed PHAR)' => [
+            null,
             '{}',
             true,
             [
@@ -52,7 +89,63 @@ class AppRequirementsFactoryTest extends TestCase
             ],
         ];
 
+        yield 'empty json & lock file (compressed PHAR)' => [
+            '{}',
+            '{}',
+            true,
+            [
+                [
+                    "return \\extension_loaded('zip');",
+                    'The application requires the extension "zip". Enable it or install a polyfill.',
+                    'The application requires the extension "zip".',
+                ],
+            ],
+        ];
+
+        yield 'json file platform requirements' => [
+            <<<'JSON'
+{
+    "require": {
+        "php": "^7.1",
+        "ext-phar": "*",
+        "acme/foo": "^1.0"
+    },
+    "require-dev": []
+}
+JSON
+            ,
+            null,
+            false,
+            [
+                [
+                    <<<'PHP'
+require_once __DIR__.'/../vendor/composer/semver/src/Semver.php';
+require_once __DIR__.'/../vendor/composer/semver/src/VersionParser.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/ConstraintInterface.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/EmptyConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/MultiConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/Constraint.php';
+
+return \Composer\Semver\Semver::satisfies(
+    sprintf('%d.%d.%d', \PHP_MAJOR_VERSION, \PHP_MINOR_VERSION, \PHP_RELEASE_VERSION),
+    '^7.1'
+);
+
+PHP
+                    ,
+                    'The application requires the version "^7.1" or greater.',
+                    'The application requires the version "^7.1" or greater.',
+                ],
+                [
+                    "return \\extension_loaded('phar');",
+                    'The application requires the extension "phar". Enable it or install a polyfill.',
+                    'The application requires the extension "phar".',
+                ],
+            ],
+        ];
+
         yield 'lock file platform requirements' => [
+            null,
             <<<'JSON'
 {
     "platform": {
@@ -83,6 +176,103 @@ PHP
                     ,
                     'The application requires the version "^7.1" or greater.',
                     'The application requires the version "^7.1" or greater.',
+                ],
+                [
+                    "return \\extension_loaded('phar');",
+                    'The application requires the extension "phar". Enable it or install a polyfill.',
+                    'The application requires the extension "phar".',
+                ],
+            ],
+        ];
+
+        yield 'json & lock file platform requirements' => [
+            <<<'JSON'
+{
+    "platform": {
+        "php": "^7.2",
+        "ext-phar": "*",
+        "acme/foo": "^1.0"
+    },
+    "platform-dev": []
+}
+JSON
+            ,
+            <<<'JSON'
+{
+    "platform": {
+        "php": "^7.1",
+        "ext-phar": "*"
+    },
+    "platform-dev": []
+}
+JSON
+            ,
+            false,
+            [
+                [
+                    <<<'PHP'
+require_once __DIR__.'/../vendor/composer/semver/src/Semver.php';
+require_once __DIR__.'/../vendor/composer/semver/src/VersionParser.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/ConstraintInterface.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/EmptyConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/MultiConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/Constraint.php';
+
+return \Composer\Semver\Semver::satisfies(
+    sprintf('%d.%d.%d', \PHP_MAJOR_VERSION, \PHP_MINOR_VERSION, \PHP_RELEASE_VERSION),
+    '^7.1'
+);
+
+PHP
+                    ,
+                    'The application requires the version "^7.1" or greater.',
+                    'The application requires the version "^7.1" or greater.',
+                ],
+                [
+                    "return \\extension_loaded('phar');",
+                    'The application requires the extension "phar". Enable it or install a polyfill.',
+                    'The application requires the extension "phar".',
+                ],
+            ],
+        ];
+
+        yield 'json file platform requirements (compressed PHAR)' => [
+            <<<'JSON'
+{
+    "require": {
+        "php": "^7.1",
+        "ext-phar": "*"
+    },
+    "require-dev": []
+}
+JSON
+            ,
+            null,
+            true,
+            [
+                [
+                    <<<'PHP'
+require_once __DIR__.'/../vendor/composer/semver/src/Semver.php';
+require_once __DIR__.'/../vendor/composer/semver/src/VersionParser.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/ConstraintInterface.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/EmptyConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/MultiConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/Constraint.php';
+
+return \Composer\Semver\Semver::satisfies(
+    sprintf('%d.%d.%d', \PHP_MAJOR_VERSION, \PHP_MINOR_VERSION, \PHP_RELEASE_VERSION),
+    '^7.1'
+);
+
+PHP
+                    ,
+                    'The application requires the version "^7.1" or greater.',
+                    'The application requires the version "^7.1" or greater.',
+                ],
+                [
+                    "return \\extension_loaded('zip');",
+                    'The application requires the extension "zip". Enable it or install a polyfill.',
+                    'The application requires the extension "zip".',
                 ],
                 [
                     "return \\extension_loaded('phar');",
@@ -93,6 +283,7 @@ PHP
         ];
 
         yield 'lock file platform requirements (compressed PHAR)' => [
+            null,
             <<<'JSON'
 {
     "platform": {
@@ -137,7 +328,79 @@ PHP
             ],
         ];
 
+        yield 'json & lock file platform requirements (compressed PHAR)' => [
+            <<<'JSON'
+{
+    "require": {
+        "php": "^7.2",
+        "ext-phar": "*"
+    },
+    "require-dev": []
+}
+JSON
+            ,
+            <<<'JSON'
+{
+    "platform": {
+        "php": "^7.1",
+        "ext-phar": "*"
+    },
+    "platform-dev": []
+}
+JSON
+            ,
+            true,
+            [
+                [
+                    <<<'PHP'
+require_once __DIR__.'/../vendor/composer/semver/src/Semver.php';
+require_once __DIR__.'/../vendor/composer/semver/src/VersionParser.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/ConstraintInterface.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/EmptyConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/MultiConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/Constraint.php';
+
+return \Composer\Semver\Semver::satisfies(
+    sprintf('%d.%d.%d', \PHP_MAJOR_VERSION, \PHP_MINOR_VERSION, \PHP_RELEASE_VERSION),
+    '^7.1'
+);
+
+PHP
+                    ,
+                    'The application requires the version "^7.1" or greater.',
+                    'The application requires the version "^7.1" or greater.',
+                ],
+                [
+                    "return \\extension_loaded('zip');",
+                    'The application requires the extension "zip". Enable it or install a polyfill.',
+                    'The application requires the extension "zip".',
+                ],
+                [
+                    "return \\extension_loaded('phar');",
+                    'The application requires the extension "phar". Enable it or install a polyfill.',
+                    'The application requires the extension "phar".',
+                ],
+            ],
+        ];
+
+        yield 'json file platform dev requirements are ignored' => [
+            <<<'JSON'
+{
+    "require": [],
+    "require-dev": {
+        "php": "^7.3",
+        "ext-json": "*"
+    }
+}
+JSON
+            ,
+            null,
+            false,
+            [],
+        ];
+
         yield 'lock file platform dev requirements are ignored' => [
+            null,
             <<<'JSON'
 {
     "platform": [],
@@ -152,7 +415,55 @@ JSON
             [],
         ];
 
+        yield 'json & lock file platform dev requirements are ignored' => [
+            <<<'JSON'
+{
+    "require": [],
+    "require-dev": {
+        "php": "^7.3",
+        "ext-json": "*"
+    }
+}
+JSON
+            ,
+            <<<'JSON'
+{
+    "platform": [],
+    "platform-dev": {
+        "php": "^7.3",
+        "ext-json": "*"
+    }
+}
+JSON
+            ,
+            false,
+            [],
+        ];
+
+        yield 'json file platform dev requirements are ignored (compressed PHAR)' => [
+            <<<'JSON'
+{
+    "require": [],
+    "require-dev": {
+        "php": "^7.3",
+        "ext-json": "*"
+    }
+}
+JSON
+            ,
+            null,
+            true,
+            [
+                [
+                    "return \\extension_loaded('zip');",
+                    'The application requires the extension "zip". Enable it or install a polyfill.',
+                    'The application requires the extension "zip".',
+                ],
+            ],
+        ];
+
         yield 'lock file platform dev requirements are ignored (compressed PHAR)' => [
+            null,
             <<<'JSON'
 {
     "platform": [],
@@ -173,7 +484,98 @@ JSON
             ],
         ];
 
+        yield 'json & lock file platform dev requirements are ignored (compressed PHAR)' => [
+            <<<'JSON'
+{
+    "require": [],
+    "require-dev": {
+        "php": "^7.3",
+        "ext-json": "*"
+    }
+}
+JSON
+            ,
+            <<<'JSON'
+{
+    "platform": [],
+    "platform-dev": {
+        "php": "^7.3",
+        "ext-json": "*"
+    }
+}
+JSON
+            ,
+            true,
+            [
+                [
+                    "return \\extension_loaded('zip');",
+                    'The application requires the extension "zip". Enable it or install a polyfill.',
+                    'The application requires the extension "zip".',
+                ],
+            ],
+        ];
+
+        yield 'json file packages requirements' => [
+            <<<'JSON'
+{
+    "require": {
+        "php": ">=5.3",
+        "ext-mbstring": "*",
+        "ext-openssl": "*",
+        "ext-pcre": "*",
+        "ext-pdo_sqlite3": "*"
+    },
+    "require-dev": []
+}
+JSON
+            ,
+            null,
+            false,
+            [
+                [
+                    <<<'PHP'
+require_once __DIR__.'/../vendor/composer/semver/src/Semver.php';
+require_once __DIR__.'/../vendor/composer/semver/src/VersionParser.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/ConstraintInterface.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/EmptyConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/MultiConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/Constraint.php';
+
+return \Composer\Semver\Semver::satisfies(
+    sprintf('%d.%d.%d', \PHP_MAJOR_VERSION, \PHP_MINOR_VERSION, \PHP_RELEASE_VERSION),
+    '>=5.3'
+);
+
+PHP
+                    ,
+                    'The application requires the version ">=5.3" or greater.',
+                    'The application requires the version ">=5.3" or greater.',
+                ],
+                [
+                    "return \\extension_loaded('mbstring');",
+                    'The application requires the extension "mbstring". Enable it or install a polyfill.',
+                    'The application requires the extension "mbstring".',
+                ],
+                [
+                    "return \\extension_loaded('openssl');",
+                    'The application requires the extension "openssl". Enable it or install a polyfill.',
+                    'The application requires the extension "openssl".',
+                ],
+                [
+                    "return \\extension_loaded('pcre');",
+                    'The application requires the extension "pcre". Enable it or install a polyfill.',
+                    'The application requires the extension "pcre".',
+                ],
+                [
+                    "return \\extension_loaded('pdo_sqlite3');",
+                    'The application requires the extension "pdo_sqlite3". Enable it or install a polyfill.',
+                    'The application requires the extension "pdo_sqlite3".',
+                ],
+            ],
+        ];
+
         yield 'lock file packages requirements' => [
+            null,
             <<<'JSON'
 {
     "packages": [
@@ -274,7 +676,182 @@ PHP
             ],
         ];
 
+        yield 'json & lock file packages requirements' => [
+            <<<'JSON'
+{
+    "require": {
+        "php": ">=5.3",
+        "ext-mbstring": "*",
+        "ext-openssl": "*",
+        "ext-pcre": "*",
+        "ext-pdo_sqlite3": "*"
+    },
+    "require-dev": []
+}
+JSON
+            ,
+            <<<'JSON'
+{
+    "packages": [
+        {
+            "name": "beberlei/assert",
+            "version": "v2.9.2",
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": []
+        },
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.1.0",
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "ext-pdo_sqlite3": "*"
+            }
+        },
+        {
+            "name": "acme/foo",
+            "version": "1.1.0",
+            "require": {
+                "ext-openssl": "*"
+            },
+            "require-dev": []
+        }
+    ],
+    "platform-dev": []
+}
+JSON
+            ,
+            false,
+            [
+                [
+                    <<<'PHP'
+require_once __DIR__.'/../vendor/composer/semver/src/Semver.php';
+require_once __DIR__.'/../vendor/composer/semver/src/VersionParser.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/ConstraintInterface.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/EmptyConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/MultiConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/Constraint.php';
+
+return \Composer\Semver\Semver::satisfies(
+    sprintf('%d.%d.%d', \PHP_MAJOR_VERSION, \PHP_MINOR_VERSION, \PHP_RELEASE_VERSION),
+    '>=5.3'
+);
+
+PHP
+                    ,
+                    'The package "beberlei/assert" requires the version ">=5.3" or greater.',
+                    'The package "beberlei/assert" requires the version ">=5.3" or greater.',
+                ],
+                [
+                    <<<'PHP'
+require_once __DIR__.'/../vendor/composer/semver/src/Semver.php';
+require_once __DIR__.'/../vendor/composer/semver/src/VersionParser.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/ConstraintInterface.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/EmptyConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/MultiConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/Constraint.php';
+
+return \Composer\Semver\Semver::satisfies(
+    sprintf('%d.%d.%d', \PHP_MAJOR_VERSION, \PHP_MINOR_VERSION, \PHP_RELEASE_VERSION),
+    '^5.3.2 || ^7.0'
+);
+
+PHP
+                    ,
+                    'The package "composer/ca-bundle" requires the version "^5.3.2 || ^7.0" or greater.',
+                    'The package "composer/ca-bundle" requires the version "^5.3.2 || ^7.0" or greater.',
+                ],
+                [
+                    "return \\extension_loaded('mbstring');",
+                    'The package "beberlei/assert" requires the extension "mbstring". Enable it or install a polyfill.',
+                    'The package "beberlei/assert" requires the extension "mbstring".',
+                ],
+                [
+                    "return \\extension_loaded('openssl');",
+                    'The package "composer/ca-bundle" requires the extension "openssl". Enable it or install a polyfill.',
+                    'The package "composer/ca-bundle" requires the extension "openssl".',
+                ],
+                [
+                    "return \\extension_loaded('openssl');",
+                    'The package "acme/foo" requires the extension "openssl". Enable it or install a polyfill.',
+                    'The package "acme/foo" requires the extension "openssl".',
+                ],
+                [
+                    "return \\extension_loaded('pcre');",
+                    'The package "composer/ca-bundle" requires the extension "pcre". Enable it or install a polyfill.',
+                    'The package "composer/ca-bundle" requires the extension "pcre".',
+                ],
+            ],
+        ];
+
+        yield 'json file dev packages are ignored' => [
+            <<<'JSON'
+{
+    "require": [],
+    "require-dev": {
+        "ext-mbstring": "*",
+        "php": ">=5.3"
+    }
+}
+JSON
+            ,
+            null,
+            false,
+            [],
+        ];
+
         yield 'lock file dev packages are ignored' => [
+            null,
+            <<<'JSON'
+{
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "beberlei/assert",
+            "version": "v2.9.2",
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": []
+        },
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.1.0",
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "ext-pdo_sqlite3": "*"
+            }
+        }
+    ]
+}
+JSON
+            ,
+            false,
+            [],
+        ];
+
+        yield 'json & lock file dev packages are ignored' => [
+            <<<'JSON'
+{
+    "require": [],
+    "require-dev": {
+        "ext-mbstring": "*",
+        "php": ">=5.3"
+    }
+}
+JSON
+            ,
             <<<'JSON'
 {
     "packages": [],
@@ -309,6 +886,7 @@ JSON
         ];
 
         yield 'duplicate requirements' => [
+            null,
             <<<'JSON'
 {
     "packages": [
@@ -399,7 +977,53 @@ PHP
             ],
         ];
 
-        yield 'it supports polyfills' => [
+        yield 'it supports polyfills (json)' => [
+            <<<'JSON'
+{
+    "require": {
+        "php": "^7.3",
+        "ext-mbstring": "*",
+        "ext-json": "*",
+        "symfony/polyfill-mbstring": "^1.0"
+    },
+    "require-dev": {
+        "symfony/polyfill-json": "^4.0"
+    }
+}
+JSON
+            ,
+            null,
+            false,
+            [
+                [
+                    <<<'PHP'
+require_once __DIR__.'/../vendor/composer/semver/src/Semver.php';
+require_once __DIR__.'/../vendor/composer/semver/src/VersionParser.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/ConstraintInterface.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/EmptyConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/MultiConstraint.php';
+require_once __DIR__.'/../vendor/composer/semver/src/Constraint/Constraint.php';
+
+return \Composer\Semver\Semver::satisfies(
+    sprintf('%d.%d.%d', \PHP_MAJOR_VERSION, \PHP_MINOR_VERSION, \PHP_RELEASE_VERSION),
+    '^7.3'
+);
+
+PHP
+                    ,
+                    'The application requires the version "^7.3" or greater.',
+                    'The application requires the version "^7.3" or greater.',
+                ],
+                [
+                    "return \\extension_loaded('json');",
+                    'The application requires the extension "json". Enable it or install a polyfill.',
+                    'The application requires the extension "json".',
+                ],
+            ],
+        ];
+
+        yield 'it supports polyfills (lock)' => [
+            null,
             <<<'JSON'
 {
     "packages": [
@@ -491,7 +1115,23 @@ PHP
             ],
         ];
 
-        yield 'libsodium polyfill' => [
+        yield 'libsodium polyfill (json)' => [
+            <<<'JSON'
+{
+    "require": {
+        "ext-libsodium": "*",
+        "paragonie/sodium_compat": "^1.0"
+    }
+}
+JSON
+            ,
+            null,
+            false,
+            [],
+        ];
+
+        yield 'libsodium polyfill (lock)' => [
+            null,
             <<<'JSON'
 {
     "platform": {
@@ -510,7 +1150,23 @@ JSON
             [],
         ];
 
-        yield 'mcrypt polyfill' => [
+        yield 'mcrypt polyfill (json)' => [
+            <<<'JSON'
+{
+    "require": {
+        "ext-mcrypt": "*",
+        "phpseclib/mcrypt_compat": "^1.0"
+    }
+}
+JSON
+            ,
+            null,
+            false,
+            [],
+        ];
+
+        yield 'mcrypt polyfill (lock)' => [
+            null,
             <<<'JSON'
 {
     "platform": {


### PR DESCRIPTION
When there is no dependencies Composer does not generate a `composer.lock` and as a result the
requirement checker could not be generated. This patch now allows to use the requirement checker
even in that situation.

Note however that this implies the requirement checker could be wrong if one has a `composer.json`
with dependencies but the `composer.lock` file went missing for some reasons. This is however and
edge case that I don't think Box should worry about.