### PR TITLE
Fail gracefully when the extension required for the compression algorithm is not loaded

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -52,6 +52,7 @@ The configuration file is a JSON object saved to a file. Note that all settings 
     "datetime_format": "?",
     "directories": "?",
     "directories-bin": "?",
+    "dump-autoload": "?",
     "files": "?",
     "files-bin": "?",
     "finder": "?",
@@ -139,6 +140,10 @@ regardless of the content of the `composer.json`.
 If a `composer.json` is found without a `composer.lock`, the it will be taken as the source of truth for establishing the
 requirements regardless of whether there is no `composer.lock` because there is no dependencies or because it has been
 removed.
+
+**Warning**: this check is still done within the PHAR. As a result, if [the required extension to open the PHAR][compression]
+due to the compression algorithm is not loaded, a hard failure will still appear: the requirement checker _cannot_ be
+executed before that.
 
 
 ## Including files
@@ -510,9 +515,13 @@ The compression (`string`|`null`) setting is the compression algorithm to use wh
 affects the individual files within the PHAR and not the PHAR as a whole ([`Phar::compressFiles()`][phar.compress]). The
 following is a list of the signature algorithms available:
 
-- `BZ2`
 - `GZ` (the most efficient most of the time)
+- `BZ2`
 - `NONE` (default)
+
+**Warning**: be aware that if compressed, the PHAR will required the appropriate extension ([`zlib`][zlib-extension] for
+`GZ` and [`bz2`][bz2-extension] for `BZ2`) to execute the PHAR. Without it, PHP will _not_ be able to open the PHAR at
+all.
 
 
 ## Signing algorithm (`algorithm`)
@@ -578,6 +587,8 @@ The metadata (`any`) setting can be any value. This value will be stored as meta
 [composer-bin]: https://getcomposer.org/doc/04-schema.md#bin
 [composer-classmap-authoritative]: https://getcomposer.org/doc/articles/autoloader-optimization.md#optimization-level-2-a-authoritative-class-maps
 [composer-no-dev-option]: https://getcomposer.org/doc/03-cli.md#dump-autoload-dumpautoload-
+[zlib-extension]: https://secure.php.net/manual/en/book.zlib.php
+[bz2-extension]: https://secure.php.net/manual/en/book.bzip2.php
 
 
 //TODO: rework the rest

--- a/src/Composer/ComposerOrchestrator.php
+++ b/src/Composer/ComposerOrchestrator.php
@@ -17,11 +17,11 @@ namespace KevinGH\Box\Composer;
 use Composer\Factory;
 use Composer\IO\NullIO;
 use Humbug\PhpScoper\Autoload\ScoperAutoloadGenerator;
+use RuntimeException;
+use Throwable;
 use function KevinGH\Box\FileSystem\dump_file;
 use function KevinGH\Box\FileSystem\file_contents;
 use function preg_replace;
-use RuntimeException;
-use Throwable;
 
 /**
  * @private

--- a/src/Console/Command/Build.php
+++ b/src/Console/Command/Build.php
@@ -17,8 +17,8 @@ namespace KevinGH\Box\Console\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use function trigger_error;
 use const E_USER_DEPRECATED;
+use function trigger_error;
 
 /**
  * @deprecated

--- a/src/RequirementChecker/AppRequirementsFactory.php
+++ b/src/RequirementChecker/AppRequirementsFactory.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 
 namespace KevinGH\Box\RequirementChecker;
 
+use Phar;
 use function array_diff_key;
 use function array_key_exists;
-use Phar;
 use function sprintf;
 use function substr;
 
@@ -166,8 +166,7 @@ final class AppRequirementsFactory
         array $composerJsonContents,
         array $composerLockContents,
         ?int $compressionAlgorithm
-    ): array
-    {
+    ): array {
         $requirements = [];
         $polyfills = [];
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -16,6 +16,7 @@ namespace KevinGH\Box;
 
 use Assert\Assertion;
 use Phar;
+use function array_key_exists;
 use function constant;
 use function define;
 use function defined;
@@ -45,6 +46,22 @@ function get_phar_compression_algorithms(): array
 /**
  * @private
  */
+function get_phar_compression_algorithm_extension(int $algorithm): ?string
+{
+    static $extensions = [
+        Phar::GZ => 'zlib',
+        Phar::BZ2 => 'bz2',
+        Phar::NONE => null,
+    ];
+
+    Assertion::true(array_key_exists($algorithm, $extensions));
+
+    return $extensions[$algorithm];
+}
+
+/**
+ * @private
+ */
 function formatted_filesize(string $path): string
 {
     Assertion::file($path);
@@ -63,6 +80,28 @@ function formatted_filesize(string $path): string
         ),
         $units[$power]
     );
+}
+
+/**
+ * @private Converts a memory string, e.g. '2000M' to bytes
+ */
+function memory_to_bytes(string $value): int
+{
+    $unit = strtolower($value[strlen($value) - 1]);
+
+    $value = (int) $value;
+    switch ($unit) {
+        case 'g':
+            $value *= 1024;
+        // no break (cumulative multiplier)
+        case 'm':
+            $value *= 1024;
+        // no break (cumulative multiplier)
+        case 'k':
+            $value *= 1024;
+    }
+
+    return $value;
 }
 
 /**

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -1515,6 +1515,7 @@ Box (repo)
     >
     > @link https://github.com/humbug/box
 ? Compressing with the algorithm "GZ"
+    > Warning: the extension "zlib" will no be required to excute the PHAR
 * Done.
 
  // You can inspect the generated PHAR with the "info" command.
@@ -1728,6 +1729,7 @@ Box (repo)
     >
     > @link https://github.com/humbug/box
 ? Compressing with the algorithm "GZ"
+    > Warning: the extension "zlib" will no be required to excute the PHAR
 * Done.
 
  // You can inspect the generated PHAR with the "info" command.


### PR DESCRIPTION
- Add a warning in the documentation and the logs of the `compile` command regarding the extension required to execute a PHAR once compressed
- Handle the compression in `Box` instead of using the leaked `Box#phar`
- Make `Box` countable
- A few minor refactoring bits

Closes #186