### PR TITLE
Allow to build an empty PHAR

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -138,6 +138,12 @@ final class Box implements Countable
         $tmp = make_tmp_dir('box', __CLASS__);
         chdir($tmp);
 
+        if ([] === $this->bufferedFiles) {
+            $this->bufferedFiles = [
+                '.box_empty' => 'A PHAR cannot be empty so Box adds this file to ensure the PHAR is created still.',
+            ];
+        }
+
         try {
             foreach ($this->bufferedFiles as $file => $contents) {
                 dump_file($file, $contents);

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -1547,6 +1547,82 @@ OUTPUT;
         );
     }
 
+    public function test_it_can_build_an_empty_PHAR(): void
+    {
+        mirror(self::FIXTURES_DIR.'/dir004', $this->tmp);
+
+        dump_file(
+            'box.json',
+            <<<'JSON'
+{
+    "stub": "stub.php",
+    "main": false
+}
+JSON
+
+        );
+
+        $commandTester = $this->getCommandTester();
+        $commandTester->execute(
+            ['command' => 'compile'],
+            [
+                'interactive' => false,
+                'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+            ]
+        );
+
+        $expected = <<<OUTPUT
+
+    ____
+   / __ )____  _  __
+  / __  / __ \| |/_/
+ / /_/ / /_/ />  <
+/_____/\____/_/|_|
+
+
+Box (repo)
+
+
+ // Loading the configuration file "/path/to/box.json.dist".
+
+* Building the PHAR "/path/to/tmp/test.phar"
+? No compactor to register
+? No main script path configured
+? Adding binary files
+    > No file found
+? Adding files
+    > No file found
+? Using stub file: /path/to/tmp/stub.php
+? No compression
+* Done.
+
+ // PHAR: 1 file (100B)
+ // You can inspect the generated PHAR with the "info" command.
+
+ // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
+
+
+OUTPUT;
+
+        $actual = $this->normalizeDisplay($commandTester->getDisplay(true));
+
+        $this->assertSame($expected, $actual);
+
+        $this->assertSame(
+            'Hello!',
+            exec('php test.phar'),
+            'Expected PHAR to be executable'
+        );
+
+        $expectedFiles = [
+            '/.box_empty',
+        ];
+
+        $actualFiles = $this->retrievePharFiles(new Phar('test.phar'));
+
+        $this->assertSame($expectedFiles, $actualFiles);
+    }
+
     public function test_it_can_build_a_PHAR_with_compressed_code(): void
     {
         mirror(self::FIXTURES_DIR.'/dir006', $this->tmp);


### PR DESCRIPTION
When a PHAR was built with no files and no main script, which is a perfectly valid case when
creating a PHAR with just a stub file for example, no PHAR was created and instead a random error
was thrown because of it.