### PR TITLE
Move Box#basePath to MapFile

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -300,7 +300,7 @@ BANNER;
         $fileMode = self::retrieveFileMode($raw);
 
         $map = self::retrieveMap($raw);
-        $fileMapper = new MapFile($map);
+        $fileMapper = new MapFile($basePath, $map);
 
         $metadata = self::retrieveMetadata($raw);
 

--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -352,10 +352,7 @@ EOF
 
         $this->logMap($fileMapper, $logger);
 
-        $box->registerFileMapping(
-            $config->getBasePath(),
-            $fileMapper
-        );
+        $box->registerFileMapping($fileMapper);
     }
 
     private function addFiles(Configuration $config, Box $box, BuildLogger $logger, SymfonyStyle $io): void

--- a/src/MapFile.php
+++ b/src/MapFile.php
@@ -14,41 +14,47 @@ declare(strict_types=1);
 
 namespace KevinGH\Box;
 
+use function KevinGH\Box\FileSystem\make_path_relative;
+
 /**
  * @internal
  * @private
  */
 final class MapFile
 {
+    private $basePath;
     private $map;
 
     /**
      * @param string[][] $map
      */
-    public function __construct(array $map)
+    public function __construct(string $basePath, array $map)
     {
+        $this->basePath = $basePath;
         $this->map = $map;
     }
 
     public function __invoke(string $path): ?string
     {
+        $relativePath = make_path_relative($path, $this->basePath);
+
         foreach ($this->map as $item) {
             foreach ($item as $match => $replace) {
                 if ('' === $match) {
-                    return $replace.'/'.$path;
+                    return $replace.'/'.$relativePath;
                 }
 
-                if (0 === strpos($path, $match)) {
+                if (0 === strpos($relativePath, $match)) {
                     return preg_replace(
                         '/^'.preg_quote($match, '/').'/',
                         $replace,
-                        $path
+                        $relativePath
                     );
                 }
             }
         }
 
-        return $path;
+        return $relativePath;
     }
 
     public function getMap(): array

--- a/tests/BoxTest.php
+++ b/tests/BoxTest.php
@@ -328,11 +328,14 @@ class BoxTest extends FileSystemTestCase
 
         file_put_contents($file, $contents);
 
-        $fileMapper = new MapFile([
-            [$file => $localPath],
-        ]);
+        $fileMapper = new MapFile(
+            $this->tmp,
+            [
+                [$file => $localPath],
+            ]
+        );
 
-        $this->box->registerFileMapping($this->tmp, $fileMapper);
+        $this->box->registerFileMapping($fileMapper);
 
         $this->box->startBuffering();
         $this->box->addFile($file);
@@ -379,11 +382,14 @@ class BoxTest extends FileSystemTestCase
 
         file_put_contents($file, $contents);
 
-        $fileMapper = new MapFile([
-            [$file => $localPath],
-        ]);
+        $fileMapper = new MapFile(
+            $this->tmp,
+            [
+                [$file => $localPath],
+            ]
+        );
 
-        $this->box->registerFileMapping($this->tmp, $fileMapper);
+        $this->box->registerFileMapping($fileMapper);
 
         $this->box->startBuffering();
         $this->box->addFile($file, null, true);
@@ -447,10 +453,13 @@ class BoxTest extends FileSystemTestCase
 
     public function test_it_maps_the_file_before_adding_it_to_the_phar(): void
     {
-        $map = new MapFile([
-            ['acme' => 'src/Foo'],
-            ['' => 'lib'],
-        ]);
+        $map = new MapFile(
+            $this->tmp,
+            [
+                ['acme' => 'src/Foo'],
+                ['' => 'lib'],
+            ]
+        );
 
         $files = [
             'acme/foo' => 'src/Foo/foo',
@@ -459,7 +468,7 @@ class BoxTest extends FileSystemTestCase
             'f2' => 'lib/f2',
         ];
 
-        $this->box->registerFileMapping($this->tmp, $map);
+        $this->box->registerFileMapping($map);
 
         foreach ($files as $file => $expectedLocal) {
             dump_file($file);
@@ -651,11 +660,14 @@ class BoxTest extends FileSystemTestCase
 
     public function test_it_can_add_files_with_a_local_path_to_the_phar(): void
     {
-        $fileMapper = new MapFile([
-            ['' => 'local'],
-        ]);
+        $fileMapper = new MapFile(
+            $this->tmp,
+            [
+                ['' => 'local'],
+            ]
+        );
 
-        $this->box->registerFileMapping($this->tmp, $fileMapper);
+        $this->box->registerFileMapping($fileMapper);
 
         $files = [
             'foo' => [
@@ -809,11 +821,14 @@ JSON
             dump_file($file, $contents);
         }
 
-        $map = new MapFile([
-            ['' => 'lib'],
-        ]);
+        $map = new MapFile(
+            $this->tmp,
+            [
+                ['' => 'lib'],
+            ]
+        );
 
-        $this->box->registerFileMapping($this->tmp, $map);
+        $this->box->registerFileMapping($map);
 
         $this->box->startBuffering();
         $this->box->addFiles(array_keys($files), true);
@@ -908,11 +923,14 @@ JSON
 
     public function test_it_can_add_binary_files_with_a_local_path_to_the_phar(): void
     {
-        $fileMapper = new MapFile([
-            ['' => 'local'],
-        ]);
+        $fileMapper = new MapFile(
+            $this->tmp,
+            [
+                ['' => 'local'],
+            ]
+        );
 
-        $this->box->registerFileMapping($this->tmp, $fileMapper);
+        $this->box->registerFileMapping($fileMapper);
 
         $files = [
             'foo' => [
@@ -988,10 +1006,13 @@ JSON
 
     public function test_it_maps_the_files_before_adding_it_to_the_phar(): void
     {
-        $map = new MapFile([
-            ['acme' => 'src/Foo'],
-            ['' => 'lib'],
-        ]);
+        $map = new MapFile(
+            $this->tmp,
+            [
+                ['acme' => 'src/Foo'],
+                ['' => 'lib'],
+            ]
+        );
 
         $files = [
             'acme/foo' => 'src/Foo/foo',
@@ -1000,7 +1021,7 @@ JSON
             'f2' => 'lib/f2',
         ];
 
-        $this->box->registerFileMapping($this->tmp, $map);
+        $this->box->registerFileMapping($map);
 
         foreach ($files as $file => $expectedLocal) {
             dump_file($file);

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -1317,6 +1317,7 @@ KevinGH\Box\Configuration {#140
     """
   -map: null
   -fileMapper: KevinGH\Box\MapFile {#140
+    -basePath: "/path/to"
     -map: array:1 [
       0 => array:1 [
         "a/deep/test/directory" => "sub"


### PR DESCRIPTION
Since the given path must be relative to the base path before being mapped, it makes more sense to
do this operation directly in the file mapper.