### PR TITLE
Refactor compactors

### DIFF
--- a/src/Compactor/Placeholder.php
+++ b/src/Compactor/Placeholder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace KevinGH\Box\Compactor;
+
+use Assert\Assertion;
+use KevinGH\Box\Compactor;
+
+final class Placeholder implements Compactor
+{
+    private $placeholders;
+
+    /**
+     * @param scalar[] $placeholders
+     */
+    public function __construct(array $placeholders)
+    {
+        Assertion::allScalar($placeholders);
+
+        $this->placeholders = $placeholders;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compact(string $file, string $contents): string
+    {
+        return str_replace(
+            array_keys($this->placeholders),
+            array_values($this->placeholders),
+            $contents
+        );
+    }
+}

--- a/src/Compactors.php
+++ b/src/Compactors.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace KevinGH\Box;
+
+final class Compactors
+{
+    private $compactors;
+
+    public function __construct(Compactor ...$compactors)
+    {
+        $this->compactors = $compactors;
+    }
+
+    public function compactContents(string $file, string $contents): string
+    {
+        return (string) array_reduce(
+            $this->compactors,
+            function (string $contents, Compactor $compactor) use ($file): string {
+                return $compactor->compact($file, $contents);
+            },
+            $contents
+        );
+    }
+
+    public function toArray(): array
+    {
+        return $this->compactors;
+    }
+}

--- a/tests/Compactor/PlaceholderTest.php
+++ b/tests/Compactor/PlaceholderTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace KevinGH\Box\Compactor;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \KevinGH\Box\Compactor\Placeholder
+ */
+class PlaceholderTest extends TestCase
+{
+    /**
+     * @dataProvider provideFilesContents
+     */
+    public function test_it_replaces_the_placeholders(array $placeholders, string $contents, string $expected): void
+    {
+        $compactor = new Placeholder($placeholders);
+
+        $actual = $compactor->compact('random file', $contents);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function provideFilesContents()
+    {
+        yield [[], '', ''];
+
+        yield [['@foo@' => 'bar'], '', ''];
+
+        yield [['@foo@' => 'bar'], 'foo', 'foo'];
+
+        yield [['@foo@' => 'bar'], '@foo@', 'bar'];
+
+        yield [
+            [
+                '@foo@' => 'oof',
+                '@bar@' => '@rab@',
+                '@baz@' => 'zab',
+            ],
+            <<<'EOF'
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam at justo nec sem pretium blandit ut eu nulla. Phasellus
+@foo@
+sed varius ipsum, quis convallis ipsum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+@foo
+ridiculus mus. Nunc vel tortor posuere, dictum diam aliquam, vestibulum augue. Integer neque arcu, finibus eget leo
+foo@
+vitae, cursus pharetra eros. Nulla scelerisque felis a quam blandit, ac convallis arcu feugiat. Maecenas sem quam,
+@foo@bar@
+gravida quis dictum et, elementum a augue. In interdum, orci eu pulvinar tristique, quam erat laoreet risus, nec viverra
+@foo@@bar@
+@foo@foo@
+purus augue a leo. Nulla auctor, augue ac ultricies imperdiet, erat purus interdum libero, eu condimentum tellus nulla
+vel nisi.
+EOF
+            ,
+            <<<'EOF'
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam at justo nec sem pretium blandit ut eu nulla. Phasellus
+oof
+sed varius ipsum, quis convallis ipsum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+@foo
+ridiculus mus. Nunc vel tortor posuere, dictum diam aliquam, vestibulum augue. Integer neque arcu, finibus eget leo
+foo@
+vitae, cursus pharetra eros. Nulla scelerisque felis a quam blandit, ac convallis arcu feugiat. Maecenas sem quam,
+oofbar@
+gravida quis dictum et, elementum a augue. In interdum, orci eu pulvinar tristique, quam erat laoreet risus, nec viverra
+oof@rab@
+ooffoo@
+purus augue a leo. Nulla auctor, augue ac ultricies imperdiet, erat purus interdum libero, eu condimentum tellus nulla
+vel nisi.
+EOF
+            ,
+        ];
+
+        yield [
+            [
+                '_@_foo_@_' => 'oof',
+                '_@_bar_@_' => '@rab@',
+                '_@_baz_@_' => 'zab',
+            ],
+            <<<'EOF'
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam at justo nec sem pretium blandit ut eu nulla. Phasellus
+_@_foo_@_
+sed varius ipsum, quis convallis ipsum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+_@_foo
+ridiculus mus. Nunc vel tortor posuere, dictum diam aliquam, vestibulum augue. Integer neque arcu, finibus eget leo
+foo_@_
+vitae, cursus pharetra eros. Nulla scelerisque felis a quam blandit, ac convallis arcu feugiat. Maecenas sem quam,
+_@_foo_@_bar_@_
+gravida quis dictum et, elementum a augue. In interdum, orci eu pulvinar tristique, quam erat laoreet risus, nec viverra
+_@_foo_@__@_bar_@_
+_@_foo_@_foo_@_
+purus augue a leo. Nulla auctor, augue ac ultricies imperdiet, erat purus interdum libero, eu condimentum tellus nulla
+vel nisi.
+EOF
+            ,
+            <<<'EOF'
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam at justo nec sem pretium blandit ut eu nulla. Phasellus
+oof
+sed varius ipsum, quis convallis ipsum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+_@_foo
+ridiculus mus. Nunc vel tortor posuere, dictum diam aliquam, vestibulum augue. Integer neque arcu, finibus eget leo
+foo_@_
+vitae, cursus pharetra eros. Nulla scelerisque felis a quam blandit, ac convallis arcu feugiat. Maecenas sem quam,
+oofbar_@_
+gravida quis dictum et, elementum a augue. In interdum, orci eu pulvinar tristique, quam erat laoreet risus, nec viverra
+oof@rab@
+ooffoo_@_
+purus augue a leo. Nulla auctor, augue ac ultricies imperdiet, erat purus interdum libero, eu condimentum tellus nulla
+vel nisi.
+EOF
+            ,
+        ];
+    }
+}

--- a/tests/CompactorsTest.php
+++ b/tests/CompactorsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace KevinGH\Box;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+
+/**
+ * @covers \KevinGH\Box\Compactors
+ */
+class CompactorsTest extends TestCase
+{
+    /**
+     * @var Compactor|ObjectProphecy
+     */
+    private $compactor1Prophecy;
+
+    /**
+     * @var Compactor
+     */
+    private $compactor1;
+
+    /**
+     * @var Compactor|ObjectProphecy
+     */
+    private $compactor2Prophecy;
+
+    /**
+     * @var Compactor
+     */
+    private $compactor2;
+
+    /**
+     * @var Compactors
+     */
+    private $compactors;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp(): void
+    {
+        $this->compactor1Prophecy = $this->prophesize(Compactor::class);
+        $this->compactor1 = $this->compactor1Prophecy->reveal();
+
+        $this->compactor2Prophecy = $this->prophesize(Compactor::class);
+        $this->compactor2 = $this->compactor2Prophecy->reveal();
+
+        $this->compactors = new Compactors($this->compactor1, $this->compactor2);
+    }
+
+    public function test_it_applies_all_compactors_in_order(): void
+    {
+        $file = 'foo';
+        $contents = 'original contents';
+
+        $this->compactor1Prophecy
+            ->compact($file, $contents)
+            ->willReturn($contentsAfterCompactor1 = 'contents after compactor1')
+        ;
+        $this->compactor2Prophecy
+            ->compact($file, $contentsAfterCompactor1)
+            ->willReturn($contentsAfterCompactor2 = 'contents after compactor2')
+        ;
+
+        $expected = $contentsAfterCompactor2;
+
+        $actual = $this->compactors->compactContents($file, $contents);
+
+        $this->assertSame($expected, $actual);
+
+        $this->compactor1Prophecy->compact(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+        $this->compactor2Prophecy->compact(Argument::cetera())->shouldHaveBeenCalledTimes(1);
+    }
+
+    public function test_it_can_be_converted_into_an_array(): void
+    {
+        $this->assertSame(
+            [
+                $this->compactor1,
+                $this->compactor2,
+            ],
+            $this->compactors->toArray()
+        );
+    }
+}


### PR DESCRIPTION
Add a new `Compactors` class which encapsulate a collection of `Compactor` instances and can apply all of them.

Also introduced a new `Placeholder` compactor: replacing the placeholders is now applying this
compactor instead of a separate dedicated step.