### PR TITLE
Add recommendations & warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
         "bamarni/composer-bin-plugin": "^1.2",
         "infection/infection": "^0.9.2",
         "mikey179/vfsStream": "^1.1",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.0",
+        "symfony/phpunit-bridge": "^4.1"
     },
     "suggest": {
         "ext-openssl": "To accelerate private key generation."

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "024a3cdadee8bf0a94ac74f91981f885",
+    "content-hash": "93e184d476461286d349a0247bc635a7",
     "packages": [
         {
             "name": "amphp/amp",
@@ -4177,6 +4177,72 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "symfony/phpunit-bridge",
+            "version": "v4.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "d5f433034543bbe3b0dfa2f34e6cc85bf839846f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/d5f433034543bbe3b0dfa2f34e6cc85bf839846f",
+                "reference": "d5f433034543bbe3b0dfa2f34e6cc85bf839846f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "suggest": {
+                "ext-zip": "Zip support is required when using bin/simple-phpunit",
+                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+            },
+            "bin": [
+                "bin/simple-phpunit"
+            ],
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                },
+                "thanks": {
+                    "name": "phpunit/phpunit",
+                    "url": "https://github.com/sebastianbergmann/phpunit"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PHPUnit Bridge",
+            "homepage": "https://symfony.com",
+            "time": "2018-08-27T17:47:02+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -644,6 +644,8 @@ available:
 
 By default PHARs are `SHA1` signed.
 
+The `OPENSSL` algorithm will require to provide [a key][key]. 
+
 
 ### The private key (`key`)
 
@@ -657,7 +659,9 @@ current working directory.
 
 The private key password  (`string`|`boolean`|`null` default `null`) setting is used to specify the pass-phrase for the
 private key. If a string is provided, it will be used as is as the pass-phrase. If `true` is provided, you will be
-prompted for the passphrase.
+prompted for the passphrase unless you are not in an interactive environment.
+
+This setting will be ignored if no [key][key] has been provided.
 
 
 ## Metadata (`metadata`)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -636,8 +636,6 @@ The algorithm (`string`|`null` default `SHA1`) setting is the signing algorithm 
 ([`Phar::setSignatureAlgorithm()`][phar.setsignaturealgorithm]). The following is a list of the signature algorithms
 available:
 
-// TODO: review which signing algorithm is recommended or should absolutely not be used
-
 - `MD5`
 - `SHA1`
 - `SHA256`
@@ -649,9 +647,7 @@ By default PHARs are `SHA1` signed.
 
 ### The private key (`key`)
 
-// TODO: review this setting + doc, default value...]
-
-The key (`string`|`null` default none) setting is used to specify the path to the private key file. The private key file
+The key (`string`|`null` default `null`) setting is used to specify the path to the private key file. The private key file
 will be used to sign the PHAR using the `OPENSSL` signature algorithm (see [Signing algorithm][algorithm]) and the
 setting will be completely ignored otherwise. If an absolute path is not provided, the path will be relative to the
 current working directory.
@@ -659,9 +655,7 @@ current working directory.
 
 ### The private key password (`key-pass`)
 
-// TODO: review this setting + doc, default value...]
-
-The private key password  (`string`|`boolean`|`null` default none) setting is used to specify the pass-phrase for the
+The private key password  (`string`|`boolean`|`null` default `null`) setting is used to specify the pass-phrase for the
 private key. If a string is provided, it will be used as is as the pass-phrase. If `true` is provided, you will be
 prompted for the passphrase.
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
 
     <php>
         <env name="BOX_ALLOW_XDEBUG" value="1"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
     </php>
 
     <testsuites>

--- a/src/Box.php
+++ b/src/Box.php
@@ -369,6 +369,8 @@ final class Box implements Countable
 
         $resource = openssl_pkey_get_private($key, (string) $password);
 
+        Assertion::isResource($resource, 'Could not retrieve the private key, check that the password is correct.');
+
         openssl_pkey_export($resource, $private);
 
         $details = openssl_pkey_get_details($resource);

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -34,7 +34,6 @@ use RuntimeException;
 use Seld\JsonLint\ParsingException;
 use SplFileInfo;
 use stdClass;
-use function strtoupper;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
 use const E_USER_DEPRECATED;
@@ -70,6 +69,7 @@ use function KevinGH\Box\FileSystem\make_path_absolute;
 use function KevinGH\Box\FileSystem\make_path_relative;
 use function preg_match;
 use function sprintf;
+use function strtoupper;
 use function substr;
 use function trigger_error;
 use function uniqid;
@@ -285,7 +285,7 @@ BANNER;
      * @param string        $mainScriptContents   The processed content of the main script file
      * @param MapFile       $fileMapper           Utility to map the files from outside and inside the PHAR
      * @param mixed         $metadata             The PHAR Metadata
-     * @param bool          $promptForPrivateKey   If the user should be prompted for the private key passphrase
+     * @param bool          $promptForPrivateKey  If the user should be prompted for the private key passphrase
      * @param scalar[]      $replacements         The processed list of replacement placeholders and their values
      * @param null|string   $shebang              The shebang line
      * @param int           $signingAlgorithm     The PHAR siging algorithm. See \Phar constants
@@ -1644,8 +1644,7 @@ BANNER;
         string $basePath,
         int $signingAlgorithm,
         ConfigurationLogger $logger
-    ): ?string
-    {
+    ): ?string {
         $raw = (array) $raw;
 
         if (array_key_exists('key', $raw) && Phar::OPENSSL !== $signingAlgorithm) {
@@ -1682,10 +1681,9 @@ BANNER;
         stdClass $raw,
         int $algorithm,
         ConfigurationLogger $logger
-    ): ?string
-    {
+    ): ?string {
         $raw = (array) $raw;
-        
+
         if (array_key_exists('key-pass', $raw) && Phar::OPENSSL !== $algorithm) {
             if (false === $raw['key-pass'] || null === $raw['key-pass']) {
                 $logger->addRecommendation(
@@ -1923,14 +1921,14 @@ BANNER;
         Assertion::inArray($algorithm, array_keys(get_phar_signing_algorithms()));
 
         Assertion::true(
-            defined('Phar::'. $algorithm),
+            defined('Phar::'.$algorithm),
             sprintf(
                 'The signing algorithm "%s" is not supported by your current PHAR version.',
                 $algorithm
             )
         );
 
-        return constant('Phar::'. $algorithm);
+        return constant('Phar::'.$algorithm);
     }
 
     private static function retrieveStubBannerContents(stdClass $raw): ?string
@@ -2005,8 +2003,7 @@ BANNER;
         stdClass $raw,
         int $signingAlgorithm,
         ConfigurationLogger $logger
-    ): bool
-    {
+    ): bool {
         if (isset($raw->{'key-pass'}) && true === $raw->{'key-pass'}) {
             if (Phar::OPENSSL !== $signingAlgorithm) {
                 $logger->addWarning(
@@ -2033,15 +2030,14 @@ BANNER;
         bool $hasComposerJson,
         bool $hasComposerLock,
         ConfigurationLogger $logger
-    ): bool
-    {
+    ): bool {
         $raw = (array) $raw;
 
         if (false === array_key_exists('check-requirements', $raw)) {
             return $hasComposerJson || $hasComposerLock;
         }
 
-        /** @var bool|null $checkRequirements */
+        /** @var null|bool $checkRequirements */
         $checkRequirements = $raw['check-requirements'];
 
         if ($checkRequirements) {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -202,8 +202,6 @@ BANNER;
         $privateKeyPath = self::retrievePrivateKeyPath($raw, $basePath, $signingAlgorithm, $messages);
         $privateKeyPassphrase = self::retrievePrivateKeyPassphrase($raw, $privateKeyPath, $signingAlgorithm, $messages);
 
-        $signingAlgorithm = self::checkSigningAlgorithm($raw, $signingAlgorithm, $privateKeyPath, $messages);
-
         $replacements = self::retrieveReplacements($raw, $file, $messages);
 
         $shebang = self::retrieveShebang($raw);
@@ -1943,23 +1941,6 @@ BANNER;
         return constant('Phar::'.$raw->algorithm);
     }
 
-    private static function checkSigningAlgorithm(
-        stdClass $raw,
-        int $signingAlgorithm,
-        ?string $privateKeyPath,
-        array &$messages
-    ): int
-    {
-        if (null === $privateKeyPath && Phar::OPENSSL === $signingAlgorithm) {
-            $messages['warning'][] = 'The signing algorithm has been switched back to the default algorithm because not'
-                .' private key could be found for the OpenSSL signing.';
-
-            return self::DEFAULT_SIGNING_ALGORITHM;
-        }
-
-        return $signingAlgorithm;
-    }
-
     private static function retrieveStubBannerContents(stdClass $raw): ?string
     {
         if (false === array_key_exists('banner', (array) $raw) || null === $raw->banner) {
@@ -2032,8 +2013,8 @@ BANNER;
     {
         if (isset($raw->{'key-pass'}) && true === $raw->{'key-pass'}) {
             if (Phar::OPENSSL !== $signingAlgorithm) {
-                $messages['warning'][] = 'A prompt for password for the private key has been requested but the signing '
-                    .'algorithm used is not "OPENSSL.';
+                $messages['warning'][] = 'A prompt for password for the private key has been requested but ignored '
+                    .'since the signing algorithm used is not "OPENSSL.';
 
                 return false;
             }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1705,7 +1705,7 @@ BANNER;
     /**
      * @return scalar[]
      */
-    private static function retrieveReplacements(stdClass $raw, ?string $file, array &$messages): array
+    private static function retrieveReplacements(stdClass $raw, ?string $file, ConfigurationLogger $logger): array
     {
         if (null === $file) {
             return [];
@@ -1733,7 +1733,7 @@ BANNER;
             $replacements[$git] = self::retrieveGitVersion($file);
         }
 
-        $datetimeFormat = self::retrieveDatetimeFormat($raw, $messages);
+        $datetimeFormat = self::retrieveDatetimeFormat($raw, $logger);
 
         if (null !== ($date = self::retrieveDatetimeNowPlaceHolder($raw))) {
             $replacements[$date] = self::retrieveDatetimeNow(

--- a/src/ConfigurationLogger.php
+++ b/src/ConfigurationLogger.php
@@ -2,11 +2,20 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace KevinGH\Box;
 
-
-use function array_keys;
 use Assert\Assertion;
+use function array_keys;
 use function trim;
 
 final class ConfigurationLogger

--- a/src/ConfigurationLogger.php
+++ b/src/ConfigurationLogger.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinGH\Box;
+
+
+use function array_keys;
+use Assert\Assertion;
+use function trim;
+
+final class ConfigurationLogger
+{
+    private $recommendations = [];
+    private $warnings = [];
+
+    public function addRecommendation(string $message): void
+    {
+        $message = trim($message);
+
+        Assertion::false('' === $message, 'Expected to have a message but a blank string was given instead.');
+
+        $this->recommendations[$message] = $message;
+    }
+
+    public function addWarning(string $message): void
+    {
+        $message = trim($message);
+
+        Assertion::false('' === $message, 'Expected to have a message but a blank string was given instead.');
+
+        $this->warnings[$message] = $message;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRecommendations(): array
+    {
+        return array_keys($this->recommendations);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getWarnings(): array
+    {
+        return array_keys($this->warnings);
+    }
+}

--- a/src/Console/Command/Compile.php
+++ b/src/Console/Command/Compile.php
@@ -674,8 +674,7 @@ EOF
         OutputInterface $output,
         CompileLogger $logger
     ): void {
-        // sign using private key, if applicable
-        //TODO: check that out
+        // Sign using private key when applicable
         remove($path.'.pubkey');
 
         $key = $config->getPrivateKeyPath();
@@ -695,7 +694,7 @@ EOF
 
         $passphrase = $config->getPrivateKeyPassphrase();
 
-        if ($config->isPrivateKeyPrompt()) {
+        if ($config->promptForPrivateKey()) {
             if (false === $input->isInteractive()) {
                 throw new RuntimeException(
                     sprintf(

--- a/src/functions.php
+++ b/src/functions.php
@@ -24,9 +24,9 @@ use function sprintf;
 use function strlen;
 
 /**
- * TODO: this function should be pushed down to the PHAR extension.
- *
  * @private
+ *
+ * @return <string, int>
  */
 function get_phar_compression_algorithms(): array
 {
@@ -56,6 +56,24 @@ function get_phar_compression_algorithm_extension(int $algorithm): ?string
     );
 
     return $extensions[$algorithm];
+}
+
+/**
+ * @private
+ *
+ * @return <string, int>
+ */
+function get_phar_signing_algorithms(): array
+{
+    static $algorithms = [
+        'MD5' => Phar::MD5,
+        'SHA1' => Phar::SHA1,
+        'SHA256' => Phar::SHA256,
+        'SHA512' => Phar::SHA512,
+        'OPENSSL' => Phar::OPENSSL,
+    ];
+
+    return $algorithms;
 }
 
 /**

--- a/tests/BoxTest.php
+++ b/tests/BoxTest.php
@@ -1546,6 +1546,30 @@ PHP
         );
     }
 
+    /**
+     * @requires extension openssl
+     */
+    public function test_it_cannot_sign_the_PHAR_using_a_private_key_with_the_wrong_password(): void
+    {
+        $key = $this->getPrivateKey()[0];
+        $password = 'wrong password';
+
+        file_put_contents($file = 'foo', $key);
+
+        $this->configureHelloWorldPhar();
+
+        try {
+            $this->box->signUsingFile($file, $password);
+
+            $this->fail('Expected exception to be thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'Could not retrieve the private key, check that the password is correct.',
+                $exception->getMessage()
+            );
+        }
+    }
+
     public function test_it_cannot_sign_the_PHAR_with_a_non_existent_file_as_private_key(): void
     {
         try {

--- a/tests/Compactor/ConfigurationLoggerTest.php
+++ b/tests/Compactor/ConfigurationLoggerTest.php
@@ -2,8 +2,17 @@
 
 declare(strict_types=1);
 
-namespace KevinGH\Box;
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
+namespace KevinGH\Box;
 
 use Generator;
 use InvalidArgumentException;

--- a/tests/Compactor/ConfigurationLoggerTest.php
+++ b/tests/Compactor/ConfigurationLoggerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinGH\Box;
+
+
+use Generator;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \KevinGH\Box\ConfigurationLogger
+ */
+class ConfigurationLoggerTest extends TestCase
+{
+    /**
+     * @var ConfigurationLogger
+     */
+    private $logs;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp(): void
+    {
+        $this->logs = new ConfigurationLogger();
+    }
+
+    public function test_it_has_no_messages_by_default(): void
+    {
+        $this->assertSame([], $this->logs->getRecommendations());
+        $this->assertSame([], $this->logs->getWarnings());
+    }
+
+    /**
+     * @dataProvider provideEmptyMessage
+     */
+    public function test_it_cannot_accept_an_empty_message(string $message): void
+    {
+        try {
+            $this->logs->addRecommendation($message);
+
+            $this->fail('Expected exception to be thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'Expected to have a message but a blank string was given instead.',
+                $exception->getMessage()
+            );
+        }
+
+        try {
+            $this->logs->addWarning($message);
+
+            $this->fail('Expected exception to be thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'Expected to have a message but a blank string was given instead.',
+                $exception->getMessage()
+            );
+        }
+    }
+
+    public function test_it_can_store_recommendations_and_warnings(): void
+    {
+        $this->logs->addRecommendation('First recommendation');
+        $this->logs->addRecommendation('Second recommendation');
+
+        $this->logs->addWarning('First warning');
+        $this->logs->addWarning('Second warning');
+
+        $this->assertSame(
+            [
+                'First recommendation',
+                'Second recommendation',
+            ],
+            $this->logs->getRecommendations()
+        );
+
+        $this->assertSame(
+            [
+                'First warning',
+                'Second warning',
+            ],
+            $this->logs->getWarnings()
+        );
+    }
+
+    public function test_it_removes_duplicated_messages(): void
+    {
+        $this->logs->addRecommendation('First recommendation');
+        $this->logs->addRecommendation('First recommendation');
+        $this->logs->addRecommendation('Second recommendation');
+
+        $this->logs->addWarning('First warning');
+        $this->logs->addWarning('First warning');
+        $this->logs->addWarning('Second warning');
+
+        $this->assertSame(
+            [
+                'First recommendation',
+                'Second recommendation',
+            ],
+            $this->logs->getRecommendations()
+        );
+
+        $this->assertSame(
+            [
+                'First warning',
+                'Second warning',
+            ],
+            $this->logs->getWarnings()
+        );
+    }
+
+    public function provideEmptyMessage(): Generator
+    {
+        yield [''];
+        yield [' '];
+    }
+}

--- a/tests/ConfigurationSigningTest.php
+++ b/tests/ConfigurationSigningTest.php
@@ -119,7 +119,10 @@ class ConfigurationSigningTest extends ConfigurationTestCase
 
         $this->assertSame([], $this->config->getRecommendations());
         $this->assertSame(
-            ['The setting "key-pass" has been set but ignored the signing algorithm is not "OPENSSL".'],
+            [
+                'A prompt for password for the private key has been requested but ignored since the signing algorithm used is not "OPENSSL.',
+                'The setting "key-pass" has been set but ignored the signing algorithm is not "OPENSSL".',
+            ],
             $this->config->getWarnings()
         );
 
@@ -152,10 +155,7 @@ class ConfigurationSigningTest extends ConfigurationTestCase
             'key' => 'key-file',
         ]);
 
-        $this->assertSame(
-            $this->tmp.'/key-file',
-            $this->config->getPrivateKeyPath()
-        );
+        $this->assertNull($this->config->getPrivateKeyPath());
 
         $this->assertSame([], $this->config->getRecommendations());
         $this->assertSame(

--- a/tests/ConfigurationSigningTest.php
+++ b/tests/ConfigurationSigningTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace KevinGH\Box;
+
+use Closure;
+use DateTimeImmutable;
+use Generator;
+use Herrera\Annotations\Tokenizer;
+use InvalidArgumentException;
+use KevinGH\Box\Compactor\DummyCompactor;
+use KevinGH\Box\Compactor\InvalidCompactor;
+use KevinGH\Box\Compactor\Php;
+use KevinGH\Box\Compactor\PhpScoper;
+use KevinGH\Box\Json\JsonValidationException;
+use Phar;
+use RuntimeException;
+use Seld\JsonLint\ParsingException;
+use stdClass;
+use const DIRECTORY_SEPARATOR;
+use const PHP_EOL;
+use function abs;
+use function array_fill_keys;
+use function date_default_timezone_set;
+use function file_put_contents;
+use function KevinGH\Box\FileSystem\dump_file;
+use function KevinGH\Box\FileSystem\file_contents;
+use function KevinGH\Box\FileSystem\remove;
+use function KevinGH\Box\FileSystem\rename;
+
+/**
+ * @covers \KevinGH\Box\Configuration
+ * @covers \KevinGH\Box\MapFile
+ */
+class ConfigurationSigningTest extends ConfigurationTestCase
+{
+    public function test_the_default_signing_is_SHA1(): void
+    {
+        $this->assertSame(Phar::SHA1, $this->config->getSigningAlgorithm());
+
+        $this->assertNull($this->config->getPrivateKeyPath());
+        $this->assertNull($this->config->getPrivateKeyPassphrase());
+        $this->assertFalse($this->config->promptForPrivateKey());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+    }
+
+    /**
+     * @dataProvider providePassFileFreeSigningAlgorithm
+     */
+    public function test_the_signing_algorithm_can_be_configured(string $algorithm, int $expected): void
+    {
+        $this->setConfig([
+            'algorithm' => $algorithm,
+        ]);
+
+        $this->assertSame($expected, $this->config->getSigningAlgorithm());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+    }
+
+    public function test_the_signing_algorithm_provided_must_be_valid(): void
+    {
+        try {
+            $this->setConfig([
+                'algorithm' => 'INVALID',
+            ]);
+
+            $this->fail('Expected exception to be thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'The signing algorithm "INVALID" is not supported.',
+                $exception->getMessage()
+            );
+        }
+    }
+
+    public function test_the_OpenSSL_algorithm_requires_a_private_key(): void
+    {
+        try {
+            $this->setConfig([
+                'algorithm' => 'OPENSSL',
+            ]);
+
+            $this->fail('Expected exception to be thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'Expected to have a private key for OpenSSL signing but none have been provided.',
+                $exception->getMessage()
+            );
+        }
+    }
+
+    /**
+     * @dataProvider providePassFileFreeSigningAlgorithm
+     */
+    public function test_it_generates_a_warning_when_a_key_pass_is_provided_but_the_algorithm_is_not_OpenSSL(string $algorithm): void
+    {
+        $this->setConfig([
+            'algorithm' => $algorithm,
+            'key-pass' => true,
+        ]);
+
+        $this->assertNull($this->config->getPrivateKeyPassphrase());
+        $this->assertFalse($this->config->promptForPrivateKey());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame(
+            ['The setting "key-pass" has been set but ignored the signing algorithm is not "OPENSSL".'],
+            $this->config->getWarnings()
+        );
+
+        foreach ([false, null] as $keyPass) {
+            $this->setConfig([
+                'algorithm' => $algorithm,
+                'key-pass' => $keyPass,
+            ]);
+
+            $this->assertNull($this->config->getPrivateKeyPassphrase());
+            $this->assertFalse($this->config->promptForPrivateKey());
+
+            $this->assertSame(
+                ['The setting "key-pass" has been set but is unnecessary since the signing algorithm is not "OPENSSL".'],
+                $this->config->getRecommendations()
+            );
+            $this->assertSame([], $this->config->getWarnings());
+        }
+    }
+
+    /**
+     * @dataProvider providePassFileFreeSigningAlgorithm
+     */
+    public function test_it_generates_a_warning_when_a_key_path_is_provided_but_the_algorithm_is_not_OpenSSL(string $algorithm): void
+    {
+        touch('key-file');
+
+        $this->setConfig([
+            'algorithm' => $algorithm,
+            'key' => 'key-file',
+        ]);
+
+        $this->assertSame(
+            $this->tmp.'/key-file',
+            $this->config->getPrivateKeyPath()
+        );
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame(
+            ['The setting "key" has been set but is ignored since the signing algorithm is not "OPENSSL".'],
+            $this->config->getWarnings()
+        );
+
+        $this->setConfig([
+            'algorithm' => $algorithm,
+            'key' => null,
+        ]);
+
+        $this->assertNull($this->config->getPrivateKeyPath());
+
+        $this->assertSame(
+            ['The setting "key" has been set but is unnecessary since the signing algorithm is not "OPENSSL".'],
+            $this->config->getRecommendations()
+        );
+        $this->assertSame([], $this->config->getWarnings());
+    }
+
+    public function test_the_key_can_be_configured(): void
+    {
+        touch('key-file');
+
+        $this->setConfig([
+            'algorithm' => 'OPENSSL',
+            'key' => 'key-file',
+        ]);
+
+        $this->assertNull($this->config->getPrivateKeyPassphrase());
+        $this->assertFalse($this->config->promptForPrivateKey());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+    }
+
+    public function test_the_key_pass_can_be_configured(): void
+    {
+        touch('key-file');
+
+        $this->setConfig([
+            'algorithm' => 'OPENSSL',
+            'key' => 'key-file',
+            'key-pass' => true,
+        ]);
+
+        $this->assertNull($this->config->getPrivateKeyPassphrase());
+        $this->assertTrue($this->config->promptForPrivateKey());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+
+        foreach ([false, null] as $keyPass) {
+            $this->setConfig([
+                'algorithm' => 'OPENSSL',
+                'key' => 'key-file',
+                'key-pass' => $keyPass,
+            ]);
+
+            $this->assertNull($this->config->getPrivateKeyPassphrase());
+            $this->assertFalse($this->config->promptForPrivateKey());
+
+            $this->assertSame([], $this->config->getRecommendations());
+            $this->assertSame([], $this->config->getWarnings());
+        }
+    }
+
+    public function providePassFileFreeSigningAlgorithm(): Generator
+    {
+        yield ['MD5', Phar::MD5];
+        yield ['SHA1', Phar::SHA1];
+        yield ['SHA256', Phar::SHA256];
+        yield ['SHA512', Phar::SHA512];
+    }
+}

--- a/tests/ConfigurationSigningTest.php
+++ b/tests/ConfigurationSigningTest.php
@@ -14,30 +14,9 @@ declare(strict_types=1);
 
 namespace KevinGH\Box;
 
-use Closure;
-use DateTimeImmutable;
 use Generator;
-use Herrera\Annotations\Tokenizer;
 use InvalidArgumentException;
-use KevinGH\Box\Compactor\DummyCompactor;
-use KevinGH\Box\Compactor\InvalidCompactor;
-use KevinGH\Box\Compactor\Php;
-use KevinGH\Box\Compactor\PhpScoper;
-use KevinGH\Box\Json\JsonValidationException;
 use Phar;
-use RuntimeException;
-use Seld\JsonLint\ParsingException;
-use stdClass;
-use const DIRECTORY_SEPARATOR;
-use const PHP_EOL;
-use function abs;
-use function array_fill_keys;
-use function date_default_timezone_set;
-use function file_put_contents;
-use function KevinGH\Box\FileSystem\dump_file;
-use function KevinGH\Box\FileSystem\file_contents;
-use function KevinGH\Box\FileSystem\remove;
-use function KevinGH\Box\FileSystem\rename;
 
 /**
  * @covers \KevinGH\Box\Configuration

--- a/tests/ConfigurationSigningTest.php
+++ b/tests/ConfigurationSigningTest.php
@@ -82,7 +82,7 @@ class ConfigurationSigningTest extends ConfigurationTestCase
             $this->fail('Expected exception to be thrown.');
         } catch (InvalidArgumentException $exception) {
             $this->assertSame(
-                'The signing algorithm "INVALID" is not supported.',
+                'Value "INVALID" is not an element of the valid values: MD5, SHA1, SHA256, SHA512, OPENSSL',
                 $exception->getMessage()
             );
         }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -50,6 +50,9 @@ class ConfigurationTest extends ConfigurationTestCase
         $config = Configuration::create('box.json', new stdClass());
 
         $this->assertSame('box.json', $config->getConfigurationFile());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_it_can_be_created_without_a_file(): void
@@ -57,9 +60,12 @@ class ConfigurationTest extends ConfigurationTestCase
         $config = Configuration::create(null, new stdClass());
 
         $this->assertNull($config->getConfigurationFile());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
-    public function test_a_default_alias_is_generted_if_no_alias_is_registered(): void
+    public function test_a_default_alias_is_generated_if_no_alias_is_registered(): void
     {
         $this->assertRegExp('/^box-auto-generated-alias-[\da-zA-Z]{13}\.phar$/', $this->config->getAlias());
         $this->assertRegExp('/^box-auto-generated-alias-[\da-zA-Z]{13}\.phar$/', $this->getNoFileConfig()->getAlias());
@@ -73,6 +79,9 @@ class ConfigurationTest extends ConfigurationTestCase
         ]);
 
         $this->assertSame('test.phar', $this->config->getAlias());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_alias_value_is_normalized(): void
@@ -83,6 +92,9 @@ class ConfigurationTest extends ConfigurationTestCase
         ]);
 
         $this->assertSame('test.phar', $this->config->getAlias());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_alias_cannot_be_empty(): void
@@ -133,6 +145,9 @@ EOF
         $this->reloadConfig();
 
         $this->assertSame($this->tmp.'/sub-dir', $this->config->getBasePath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_if_there_is_no_file_the_default_base_path_used_is_the_current_working_directory(): void
@@ -146,13 +161,16 @@ EOF
         rename(self::DEFAULT_FILE, $basePath.DIRECTORY_SEPARATOR.self::DEFAULT_FILE);
 
         $this->setConfig([
-                'base-path' => $basePath,
+            'base-path' => $basePath,
         ]);
 
         $this->assertSame(
             $this->tmp.DIRECTORY_SEPARATOR.'test',
             $this->config->getBasePath()
         );
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_a_non_existent_directory_cannot_be_used_as_a_base_path(): void
@@ -203,6 +221,9 @@ EOF
         $expected = $this->tmp.DIRECTORY_SEPARATOR.'dir';
 
         $this->assertSame($expected, $this->config->getBasePath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_base_path_value_is_normalized(): void
@@ -217,6 +238,9 @@ EOF
         $expected = $this->tmp.DIRECTORY_SEPARATOR.'dir';
 
         $this->assertSame($expected, $this->config->getBasePath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     /**
@@ -246,6 +270,9 @@ EOF
 
         $this->assertSame($expectedLock, $this->config->getComposerLock());
         $this->assertSame($expectedLockContents, $this->config->getDecodedComposerLockContents());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_it_throws_an_error_when_a_composer_file_is_found_but_invalid(): void
@@ -307,6 +334,9 @@ EOF
 
         $this->assertFalse($this->config->dumpAutoload());
 
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+
         file_put_contents('composer.json', '{}');
 
         $this->setConfig([]);
@@ -317,6 +347,9 @@ EOF
         $this->setConfig(['dump-autoload' => null]);
 
         $this->assertTrue($this->config->dumpAutoload());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_autoloader_is_can_be_configured(): void
@@ -330,12 +363,18 @@ EOF
         $this->assertFalse($this->config->dumpAutoload());
         $this->assertTrue($this->getNoFileConfig()->dumpAutoload());
 
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+
         $this->setConfig([
             'dump-autoload' => true,
         ]);
 
         $this->assertTrue($this->config->dumpAutoload());
         $this->assertTrue($this->getNoFileConfig()->dumpAutoload());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_autoloader_cannot_be_dumped_if_no_composer_json_file_is_found(): void
@@ -345,6 +384,9 @@ EOF
         ]);
 
         $this->assertFalse($this->config->dumpAutoload());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_it_excludes_the_composer_files_by_default(): void
@@ -355,6 +397,9 @@ EOF
 
         $this->assertTrue($this->config->excludeComposerFiles());
         $this->assertTrue($this->getNoFileConfig()->excludeComposerFiles());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_excluding_the_composer_files_can_be_configured(): void
@@ -365,11 +410,17 @@ EOF
 
         $this->assertTrue($this->config->excludeComposerFiles());
 
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+
         $this->setConfig([
             'exclude-composer-files' => false,
         ]);
 
         $this->assertFalse($this->config->excludeComposerFiles());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_no_compactors_is_configured_by_default(): void
@@ -392,6 +443,9 @@ EOF
 
         $this->assertInstanceOf(Php::class, $compactors[0]);
         $this->assertInstanceOf(DummyCompactor::class, $compactors[1]);
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_it_cannot_get_the_compactors_with_an_invalid_class(): void
@@ -484,7 +538,11 @@ EOF
         ]);
 
         $compactors = $this->config->getCompactors();
+
         $this->assertSame('custom', $compactors[0]->getScoper()->getPrefix());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_no_compression_algorithm_is_configured_by_default(): void
@@ -501,6 +559,9 @@ EOF
         ]);
 
         $this->assertSame(Phar::BZ2, $this->config->getCompressionAlgorithm());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     /**
@@ -546,6 +607,9 @@ EOF
 
         $this->assertSame(420, $this->config->getFileMode());
 
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+
         // Decimal value provided
         $this->setConfig([
             'files' => [self::DEFAULT_FILE],
@@ -553,6 +617,9 @@ EOF
         ]);
 
         $this->assertSame(420, $this->config->getFileMode());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_a_main_script_path_is_configured_by_default(): void
@@ -584,6 +651,9 @@ JSON
 
         $this->assertTrue($this->getNoFileConfig()->hasMainScript());
         $this->assertSame($this->tmp.DIRECTORY_SEPARATOR.'bin/foo', $this->getNoFileConfig()->getMainScriptPath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_first_composer_bin_is_used_as_the_main_script_by_default(): void
@@ -608,6 +678,9 @@ JSON
         $this->assertTrue($this->config->hasMainScript());
         $this->assertSame($this->tmp.DIRECTORY_SEPARATOR.'bin/foo', $this->config->getMainScriptPath());
         $this->assertSame($this->tmp.DIRECTORY_SEPARATOR.'bin/foo', $this->getNoFileConfig()->getMainScriptPath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_main_script_can_be_configured(): void
@@ -634,6 +707,9 @@ JSON
         $this->assertTrue($this->config->hasMainScript());
         $this->assertSame($this->tmp.'/test.php', $this->config->getMainScriptPath());
         $this->assertSame('Main script contents', $this->config->getMainScriptContents());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_main_script_path_is_normalized(): void
@@ -643,6 +719,9 @@ JSON
         $this->setConfig(['main' => ' test.php ']);
 
         $this->assertSame($this->tmp.'/test.php', $this->config->getMainScriptPath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_main_script_content_ignores_shebang_line(): void
@@ -652,6 +731,9 @@ JSON
         $this->setConfig(['main' => 'test.php']);
 
         $this->assertSame('test', $this->config->getMainScriptContents());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_it_cannot_get_the_main_script_if_file_does_not_exists(): void
@@ -710,6 +792,9 @@ JSON
                 $exception->getMessage()
             );
         }
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_main_script_cannot_be_enabled(): void
@@ -767,6 +852,9 @@ JSON
             'b/second/test/path/sub/path/file.php',
             $mapFile('second/test/path/sub/path/file.php')
         );
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_no_metadata_is_configured_by_default(): void
@@ -782,6 +870,9 @@ JSON
         ]);
 
         $this->assertSame(123, $this->config->getMetadata());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_get_default_output_path(): void
@@ -794,6 +885,9 @@ JSON
             $this->tmp.DIRECTORY_SEPARATOR.'index.phar',
             $this->config->getTmpOutputPath()
         );
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_output_path_is_configurable(): void
@@ -811,6 +905,9 @@ JSON
             $this->tmp.DIRECTORY_SEPARATOR.'test.phar',
             $this->config->getTmpOutputPath()
         );
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_output_path_is_relative_to_the_base_path(): void
@@ -831,6 +928,9 @@ JSON
             $this->tmp.'/sub-dir/test.phar',
             $this->config->getTmpOutputPath()
         );
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_output_path_is_not_relative_to_the_base_path_if_is_absolute(): void
@@ -851,6 +951,9 @@ JSON
             $this->tmp.'/test.phar',
             $this->config->getTmpOutputPath()
         );
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_output_path_is_normalized(): void
@@ -868,6 +971,9 @@ JSON
             $this->tmp.DIRECTORY_SEPARATOR.'test.phar',
             $this->config->getTmpOutputPath()
         );
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_output_path_can_omit_the_PHAR_extension(): void
@@ -885,6 +991,9 @@ JSON
             $this->tmp.DIRECTORY_SEPARATOR.'test.phar',
             $this->config->getTmpOutputPath()
         );
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_get_default_output_path_depends_on_the_input(): void
@@ -899,46 +1008,9 @@ JSON
             $this->tmp.'/bin/acme.phar',
             $this->config->getOutputPath()
         );
-    }
 
-    public function testGetPrivateKeyPassphrase(): void
-    {
-        $this->assertNull($this->config->getPrivateKeyPassphrase());
-    }
-
-    public function testGetPrivateKeyPassphraseSet(): void
-    {
-        $this->setConfig([
-            'key-pass' => 'test',
-            'files' => [self::DEFAULT_FILE],
-        ]);
-
-        $this->assertSame('test', $this->config->getPrivateKeyPassphrase());
-    }
-
-    public function testGetPrivateKeyPassphraseSetBoolean(): void
-    {
-        $this->setConfig([
-            'key-pass' => true,
-            'files' => [self::DEFAULT_FILE],
-        ]);
-
-        $this->assertNull($this->config->getPrivateKeyPassphrase());
-    }
-
-    public function testGetPrivateKeyPath(): void
-    {
-        $this->assertNull($this->config->getPrivateKeyPath());
-    }
-
-    public function testGetPrivateKeyPathSet(): void
-    {
-        $this->setConfig([
-            'key' => 'test.pem',
-            'files' => [self::DEFAULT_FILE],
-        ]);
-
-        $this->assertSame('test.pem', $this->config->getPrivateKeyPath());
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_no_replacements_are_configured_by_default(): void
@@ -954,6 +1026,9 @@ JSON
         ]);
 
         $this->assertSame([], $this->config->getReplacements());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_replacement_map_can_be_configured(): void
@@ -993,6 +1068,9 @@ JSON
         );
         $this->assertCount(7, $values);
 
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+
         touch('foo');
         exec('git add foo');
         exec('git commit -m "Adding another test file."');
@@ -1028,6 +1106,9 @@ JSON
         if ($this->isWindows()) {
             exec('rd /S /Q .git');
         }
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_datetime_replacement_has_a_default_date_format(): void
@@ -1039,6 +1120,9 @@ JSON
             $this->config->getReplacements()['@date_time@']
         );
         $this->assertCount(1, $this->config->getReplacements());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_datetime_is_converted_to_UTC(): void
@@ -1056,6 +1140,9 @@ JSON
         $configDateTime = new DateTimeImmutable($this->config->getReplacements()['@date_time@']);
 
         $this->assertLessThan(10, abs($configDateTime->getTimestamp() - $now->getTimestamp()));
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_datetime_format_must_be_valid(): void
@@ -1086,6 +1173,9 @@ JSON
             '/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/',
             $values['@date_time@']
         );
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_replacement_sigil_can_be_a_chain_of_characters(): void
@@ -1099,6 +1189,9 @@ JSON
             ['__foo__' => 'bar'],
             $this->config->getReplacements()
         );
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_config_has_a_default_shebang(): void
@@ -1116,6 +1209,9 @@ JSON
         $actual = $this->config->getShebang();
 
         $this->assertSame($expected, $actual);
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_it_cannot_retrieve_the_git_hash_if_not_in_a_git_repository(): void
@@ -1148,6 +1244,9 @@ JSON
         ]);
 
         $this->assertNull($this->config->getShebang());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_cannot_register_an_invalid_shebang(): void
@@ -1224,38 +1323,9 @@ JSON
         $actual = $this->config->getShebang();
 
         $this->assertSame($expected, $actual);
-    }
 
-    public function testGetSigningAlgorithm(): void
-    {
-        $this->assertSame(Phar::SHA1, $this->config->getSigningAlgorithm());
-    }
-
-    public function testGetSigningAlgorithmSetString(): void
-    {
-        $this->setConfig([
-            'algorithm' => 'MD5',
-            'files' => [self::DEFAULT_FILE],
-        ]);
-
-        $this->assertSame(Phar::MD5, $this->config->getSigningAlgorithm());
-    }
-
-    public function testGetSigningAlgorithmInvalidString(): void
-    {
-        try {
-            $this->setConfig([
-                'algorithm' => 'INVALID',
-                'files' => [self::DEFAULT_FILE],
-            ]);
-
-            $this->fail('Expected exception to be thrown.');
-        } catch (InvalidArgumentException $exception) {
-            $this->assertSame(
-                'The signing algorithm "INVALID" is not supported.',
-                $exception->getMessage()
-            );
-        }
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_there_is_a_banner_registered_by_default(): void
@@ -1282,6 +1352,9 @@ BANNER;
 
         $this->assertSame($expected, $this->config->getStubBannerContents());
         $this->assertNull($this->config->getStubBannerPath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     /**
@@ -1296,6 +1369,9 @@ BANNER;
 
         $this->assertSame($banner, $this->config->getStubBannerContents());
         $this->assertNull($this->config->getStubBannerPath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_banner_can_be_disabled(): void
@@ -1307,6 +1383,9 @@ BANNER;
 
         $this->assertNull($this->config->getStubBannerContents());
         $this->assertNull($this->config->getStubBannerPath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_banner_must_be_a_valid_value(): void
@@ -1338,6 +1417,9 @@ BANNER;
 
         $this->assertSame($expected, $this->config->getStubBannerContents());
         $this->assertNull($this->config->getStubBannerPath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_a_custom_multiline_banner_can_be_registered(): void
@@ -1357,6 +1439,9 @@ COMMENT;
 
         $this->assertSame($comment, $this->config->getStubBannerContents());
         $this->assertNull($this->config->getStubBannerPath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_a_custom_banner_from_a_file_can_be_registered(): void
@@ -1378,6 +1463,9 @@ COMMENT;
 
         $this->assertSame($comment, $this->config->getStubBannerContents());
         $this->assertSame($this->tmp.DIRECTORY_SEPARATOR.'banner', $this->config->getStubBannerPath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_banner_value_is_discarded_if_a_banner_file_is_registered(): void
@@ -1400,6 +1488,9 @@ COMMENT;
 
         $this->assertSame($comment, $this->config->getStubBannerContents());
         $this->assertSame($this->tmp.DIRECTORY_SEPARATOR.'banner', $this->config->getStubBannerPath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_content_of_the_custom_banner_file_is_normalized(): void
@@ -1429,6 +1520,9 @@ COMMENT;
 
         $this->assertSame($expected, $this->config->getStubBannerContents());
         $this->assertSame($this->tmp.DIRECTORY_SEPARATOR.'banner', $this->config->getStubBannerPath());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_custom_banner_file_must_exists_when_provided(): void
@@ -1465,6 +1559,9 @@ COMMENT;
 
         $this->assertSame($this->tmp.DIRECTORY_SEPARATOR.'custom-stub.php', $this->config->getStubPath());
         $this->assertFalse($this->config->isStubGenerated());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_stub_can_be_generated(): void
@@ -1476,6 +1573,9 @@ COMMENT;
 
         $this->assertNull($this->config->getStubPath());
         $this->assertTrue($this->config->isStubGenerated());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_default_stub_can_be_used(): void
@@ -1487,6 +1587,9 @@ COMMENT;
 
         $this->assertNull($this->config->getStubPath());
         $this->assertFalse($this->config->isStubGenerated());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function testIsInterceptFileFuncs(): void
@@ -1502,31 +1605,9 @@ COMMENT;
         ]);
 
         $this->assertTrue($this->config->isInterceptFileFuncs());
-    }
 
-    public function testIsPrivateKeyPrompt(): void
-    {
-        $this->assertFalse($this->config->isPrivateKeyPrompt());
-    }
-
-    public function testIsPrivateKeyPromptSet(): void
-    {
-        $this->setConfig([
-            'key-pass' => true,
-            'files' => [self::DEFAULT_FILE],
-        ]);
-
-        $this->assertTrue($this->config->isPrivateKeyPrompt());
-    }
-
-    public function testIsPrivateKeyPromptSetString(): void
-    {
-        $this->setConfig([
-            'key-pass' => 'test',
-            'files' => [self::DEFAULT_FILE],
-        ]);
-
-        $this->assertFalse($this->config->isPrivateKeyPrompt());
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_requirement_checker_is_enabled_by_default_if_a_composer_lock_or_json_file_is_found(): void
@@ -1539,17 +1620,26 @@ COMMENT;
 
         $this->assertTrue($this->config->checkRequirements());
 
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+
         file_put_contents('composer.json', '{}');
 
         $this->reloadConfig();
 
         $this->assertTrue($this->config->checkRequirements());
 
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+
         remove('composer.lock');
 
         $this->reloadConfig();
 
         $this->assertTrue($this->config->checkRequirements());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_requirement_checker_can_be_disabled(): void
@@ -1560,11 +1650,17 @@ COMMENT;
 
         $this->assertFalse($this->config->checkRequirements());
 
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+
         file_put_contents('composer.lock', '{}');
 
         $this->reloadConfig();
 
         $this->assertFalse($this->config->checkRequirements());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_it_can_be_created_with_only_default_values(): void
@@ -1583,6 +1679,7 @@ COMMENT;
         $this->assertSame($this->tmp, $this->config->getBasePath());
         $this->assertSame([], $this->config->getBinaryFiles());
         $this->assertSame([], $this->config->getCompactors());
+        $this->assertFalse($this->config->hasAutodiscoveredFiles());
         $this->assertNull($this->config->getComposerJson());
         $this->assertNull($this->config->getComposerLock());
         $this->assertNull($this->config->getCompressionAlgorithm());
@@ -1829,6 +1926,14 @@ COMMENT
             null,
             null,
         ];
+    }
+
+    public function providePassFileFreeSigningAlgorithm(): Generator
+    {
+        yield ['MD5', Phar::MD5];
+        yield ['SHA1', Phar::SHA1];
+        yield ['SHA256', Phar::SHA256];
+        yield ['SHA512', Phar::SHA512];
     }
 
     /**

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -352,7 +352,7 @@ EOF
         $this->assertSame([], $this->config->getWarnings());
     }
 
-    public function test_the_autoloader_is_can_be_configured(): void
+    public function test_the_autoloader_dumping_can_be_configured(): void
     {
         file_put_contents('composer.json', '{}');
 
@@ -373,7 +373,10 @@ EOF
         $this->assertTrue($this->config->dumpAutoload());
         $this->assertTrue($this->getNoFileConfig()->dumpAutoload());
 
-        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame(
+            ['The "dump-autoload" setting has been set but is unnecessary since its value is the default value.'],
+            $this->config->getRecommendations()
+        );
         $this->assertSame([], $this->config->getWarnings());
     }
 
@@ -385,8 +388,14 @@ EOF
 
         $this->assertFalse($this->config->dumpAutoload());
 
-        $this->assertSame([], $this->config->getRecommendations());
-        $this->assertSame([], $this->config->getWarnings());
+        $this->assertSame(
+            ['The "dump-autoload" setting has been set but is unnecessary since its value is the default value.'],
+            $this->config->getRecommendations()
+        );
+        $this->assertSame(
+            ['The "dump-autoload" setting has been set but has been ignored because the composer.json file necessary for it could not be found'],
+            $this->config->getWarnings()
+        );
     }
 
     public function test_it_excludes_the_composer_files_by_default(): void

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1622,38 +1622,6 @@ COMMENT;
         $this->assertSame([], $this->config->getWarnings());
     }
 
-    public function test_the_requirement_checker_is_enabled_by_default_if_a_composer_lock_or_json_file_is_found(): void
-    {
-        $this->assertFalse($this->config->checkRequirements());
-
-        file_put_contents('composer.lock', '{}');
-
-        $this->reloadConfig();
-
-        $this->assertTrue($this->config->checkRequirements());
-
-        $this->assertSame([], $this->config->getRecommendations());
-        $this->assertSame([], $this->config->getWarnings());
-
-        file_put_contents('composer.json', '{}');
-
-        $this->reloadConfig();
-
-        $this->assertTrue($this->config->checkRequirements());
-
-        $this->assertSame([], $this->config->getRecommendations());
-        $this->assertSame([], $this->config->getWarnings());
-
-        remove('composer.lock');
-
-        $this->reloadConfig();
-
-        $this->assertTrue($this->config->checkRequirements());
-
-        $this->assertSame([], $this->config->getRecommendations());
-        $this->assertSame([], $this->config->getWarnings());
-    }
-
     public function test_the_requirement_checker_can_be_disabled(): void
     {
         $this->setConfig([
@@ -1673,6 +1641,75 @@ COMMENT;
 
         $this->assertSame([], $this->config->getRecommendations());
         $this->assertSame([], $this->config->getWarnings());
+    }
+
+    public function test_the_requirement_checker_is_enabled_by_default_if_a_composer_lock_or_json_file_is_found(): void
+    {
+        $this->assertFalse($this->config->checkRequirements());
+
+        file_put_contents('composer.lock', '{}');
+
+        $this->reloadConfig();
+
+        $this->assertTrue($this->config->checkRequirements());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+
+        file_put_contents('composer.json', '{}');
+        remove('composer.lock');
+
+        $this->reloadConfig();
+
+        $this->assertTrue($this->config->checkRequirements());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+
+        file_put_contents('composer.lock', '{}');
+
+        $this->reloadConfig();
+
+        $this->assertTrue($this->config->checkRequirements());
+
+        $this->assertSame([], $this->config->getRecommendations());
+        $this->assertSame([], $this->config->getWarnings());
+    }
+
+    public function test_the_requirement_checker_can_be_enabled(): void
+    {
+        file_put_contents('composer.json', '{}');
+        file_put_contents('composer.lock', '{}');
+
+        $this->setConfig([
+            'check-requirements' => true,
+        ]);
+
+        $this->assertTrue($this->config->checkRequirements());
+
+        $this->assertSame(
+            ['The "check-requirements" setting has been set but is unnecessary since its value is the default value'],
+            $this->config->getRecommendations()
+        );
+        $this->assertSame([], $this->config->getWarnings());
+    }
+
+    public function test_the_requirement_checker_is_forcibly_disabled_if_the_composer_files_could_not_be_found(): void
+    {
+        $this->setConfig([
+            'check-requirements' => true,
+        ]);
+
+        $this->assertFalse($this->config->checkRequirements());
+
+        $this->assertSame(
+            ['The "check-requirements" setting has been set but is unnecessary since its value is the default value'],
+            $this->config->getRecommendations()
+        );
+        $this->assertSame(
+            ['The requirement checker could not be used because the composer.json and composer.lock file could not be found.'],
+            $this->config->getWarnings()
+        );
     }
 
     public function test_it_can_be_created_with_only_default_values(): void

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1060,7 +1060,7 @@ JSON
             'git-version' => 'git_version',
             'replacements' => ['rand' => $rand = random_int(0, getrandmax())],
             'datetime' => 'date_time',
-            'datetime_format' => 'Y:m:d',
+            'datetime-format' => 'Y:m:d',
         ]);
 
         $values = $this->config->getReplacements();
@@ -1094,7 +1094,7 @@ JSON
             'replacements' => ['rand' => $rand = random_int(0, getrandmax())],
             'replacement-sigil' => '$',
             'datetime' => 'date_time',
-            'datetime_format' => 'Y:m:d',
+            'datetime-format' => 'Y:m:d',
         ]);
 
         $values = $this->config->getReplacements();
@@ -1157,7 +1157,7 @@ JSON
     public function test_the_datetime_format_must_be_valid(): void
     {
         try {
-            $this->setConfig(['datetime_format' => 'ü']);
+            $this->setConfig(['datetime-format' => 'ü']);
 
             $this->fail('Expected exception to be thrown.');
         } catch (InvalidArgumentException $exception) {
@@ -1168,6 +1168,9 @@ JSON
         }
     }
 
+    /**
+     * @group legacy
+     */
     public function test_the_new_datetime_format_setting_takes_precedence_over_the_old_one(): void
     {
         $this->setConfig([

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -2766,6 +2766,36 @@ OUTPUT;
         $this->assertSame('Acme', $phpScoperNamespace);
     }
 
+    public function test_it_cannot_sign_a_PHAR_with_the_OpenSSL_algorithm_without_a_private_key(): void
+    {
+        mirror(self::FIXTURES_DIR.'/dir010', $this->tmp);
+
+        file_put_contents(
+            'box.json',
+            json_encode(
+                [
+                    'algorithm' => 'OPENSSL',
+                ]
+            )
+        );
+
+        $this->commandTester->setInputs(['test']);    // Set input for the passphrase
+
+        try {
+            $this->commandTester->execute(
+                ['command' => 'compile'],
+                ['interactive' => true]
+            );
+
+            $this->fail('Expected exception to be thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'Expected to have a private key for OpenSSL signing but none have been provided.',
+                $exception->getMessage()
+            );
+        }
+    }
+
     public function provideAliasConfig(): Generator
     {
         yield [true];

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -110,6 +110,7 @@ class CompileTest extends CommandTestCase
                     'files' => ['test.php'],
                     'finder' => [['in' => 'one']],
                     'finder-bin' => [['in' => 'two']],
+                    'algorithm' => 'OPENSSL',
                     'key' => 'private.key',
                     'key-pass' => true,
                     'main' => 'run.php',
@@ -192,6 +193,8 @@ OUTPUT;
         );
 
         $phar = new Phar('test.phar');
+
+        $this->assertSame('OpenSSL', $phar->getSignature()['hash_type']);
 
         // Check PHAR content
         $actualStub = $this->normalizeDisplay($phar->getStub());
@@ -305,6 +308,7 @@ PHP;
                     'files' => ['test.php'],
                     'finder' => [['in' => 'one']],
                     'finder-bin' => [['in' => 'two']],
+                    'algorithm' => 'OPENSSL',
                     'key' => 'private.key',
                     'key-pass' => true,
                     'main' => 'run.php',
@@ -402,6 +406,8 @@ OUTPUT;
         );
 
         $phar = new Phar('index.phar');
+
+        $this->assertSame('SHA-1', $phar->getSignature()['hash_type']);
 
         // Check PHAR content
         $actualStub = preg_replace(
@@ -767,6 +773,7 @@ PHP;
                     'files' => ['test.php'],
                     'finder' => [['in' => 'one']],
                     'finder-bin' => [['in' => 'two']],
+                    'algorithm' => 'OPENSSL',
                     'key' => 'private.key',
                     'key-pass' => true,
                     'main' => 'run.php',
@@ -867,6 +874,7 @@ OUTPUT;
                     'files' => ['test.php'],
                     'finder' => [['in' => 'one']],
                     'finder-bin' => [['in' => 'two']],
+                    'algorithm' => 'OPENSSL',
                     'key' => 'private.key',
                     'key-pass' => true,
                     'main' => 'run.php',
@@ -973,6 +981,7 @@ OUTPUT;
                     'files' => ['test.php'],
                     'finder' => [['in' => 'one']],
                     'finder-bin' => [['in' => 'two']],
+                    'algorithm' => 'OPENSSL',
                     'key' => 'private.key',
                     'key-pass' => true,
                     'main' => 'run.php',
@@ -1369,11 +1378,11 @@ KevinGH\Box\Configuration {#140
   -tmpOutputPath: "/path/to/test.phar"
   -outputPath: "/path/to/test.phar"
   -privateKeyPassphrase: null
-  -privateKeyPath: "private.key"
-  -isPrivateKeyPrompt: true
+  -privateKeyPath: "/path/to/private.key"
+  -promptForPrivateKey: true
   -processedReplacements: []
   -shebang: "$shebang"
-  -signingAlgorithm: 2
+  -signingAlgorithm: 16
   -stubBannerContents: """
     multiline\\n
     custom banner
@@ -1383,6 +1392,8 @@ KevinGH\Box\Configuration {#140
   -isInterceptFileFuncs: false
   -isStubGenerated: true
   -checkRequirements: true
+  -warnings: []
+  -recommendations: []
 }
 
 EOF;
@@ -1456,6 +1467,7 @@ EOF;
                     'files' => ['test.php'],
                     'finder' => [['in' => 'one']],
                     'finder-bin' => [['in' => 'two']],
+                    'algorithm' => 'OPENSSL',
                     'key' => 'private.key',
                     'key-pass' => true,
                     'main' => 'run.php',
@@ -1598,6 +1610,7 @@ PHP
                     'files' => ['test.php'],
                     'finder' => [['in' => 'one']],
                     'finder-bin' => [['in' => 'two']],
+                    'algorithm' => 'OPENSSL',
                     'key' => 'private.key',
                     'key-pass' => true,
                     'main' => 'run.php',


### PR DESCRIPTION
Related to #123.

The current implementation only adds the API at the `Configuration` level. Some TODOs have been changed as well in favour of that new system but I am certain there is more "recommendations" that could be added.

To completely close #123 more work needs to be done on the UI for the user to be able to read them.

Other notable changes:

- Add the Symfony PHPUnit bridge in order to notice the deprecation notice messages when running the tests
- Fail gracefully (i.e. with a meaningful message) when a wrong password has been provided to retrieve the private key necessary for OpenSSL signing
- Rename `isPrivateKeyPrompt()` to `promptPrivateKey()`. The old method is kept for BC but is marked as deprecated.
- Reworking the PHAR built-in signing part:
    - An error is thrown if no path is provided for the key but the OpenSSL algorithm is requested for signing
    - No longer allow any invalid signing algorithm (before the only condition was that it was a known constant from the `Phar` class)
    - Warnings and recommendations have been added for various `algorithm`, `key` and `key-pass` combinations
- Migrated from `datetime_format` which is deprecated to `datetime-format`
- Implemented various recommendations/warnings