### PR TITLE
Remove unnecessary check_requirements.php file

### DIFF
--- a/src/RequirementChecker/RequirementsDumper.php
+++ b/src/RequirementChecker/RequirementsDumper.php
@@ -26,27 +26,6 @@ use function var_export;
  */
 final class RequirementsDumper
 {
-    public const CHECK_FILE_NAME = 'check_requirements.php';
-
-    private const REQUIREMENTS_CHECKER_TEMPLATE = <<<'PHP'
-<?php
-
-/*
- * This file is part of the box project.
- *
- * (c) Kevin Herrera <kevin@herrera.io>
- *     Théo Fidry <theo.fidry@gmail.com>
- *
- * This source file is subject to the MIT license that is bundled
- * with this source code in the file LICENSE.
- */
-
-namespace KevinGH\Box\RequirementChecker;
-
-require 'bin/check-requirements.php';
-
-PHP;
-
     private const REQUIREMENTS_CONFIG_TEMPLATE = <<<'PHP'
 <?php
 
@@ -64,7 +43,6 @@ PHP;
 
         $filesWithContents = [
             self::dumpRequirementsConfig($decodedComposerJsonContents, $decodedComposerLockContents, $compressionAlgorithm),
-            [self::CHECK_FILE_NAME, self::REQUIREMENTS_CHECKER_TEMPLATE],
         ];
 
         /** @var SplFileInfo[] $requirementCheckerFiles */

--- a/src/StubGenerator.php
+++ b/src/StubGenerator.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace KevinGH\Box;
 
 use Assert\Assertion;
-use KevinGH\Box\RequirementChecker\RequirementsDumper;
 
 /**
  * Generates a new PHP bootstrap loader stub for a PHAR.
@@ -24,7 +23,7 @@ use KevinGH\Box\RequirementChecker\RequirementsDumper;
  */
 final class StubGenerator
 {
-    private const CHECK_FILE_NAME = RequirementsDumper::CHECK_FILE_NAME;
+    private const CHECK_FILE_NAME = 'bin/check-requirements.php';
 
     private const STUB_TEMPLATE = <<<'STUB'
 __BOX_SHEBANG__

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -179,7 +179,7 @@ Private key passphrase:
 No recommendation found.
 No warning found.
 
- // PHAR: 45 files (100B)
+ // PHAR: 44 files (100B)
  // You can inspect the generated PHAR with the "info" command.
 
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
@@ -213,7 +213,7 @@ $shebang
 
 Phar::mapPhar('alias-test.phar');
 
-require 'phar://alias-test.phar/.box/check_requirements.php';
+require 'phar://alias-test.phar/.box/bin/check-requirements.php';
 
 require 'phar://alias-test.phar/run.php';
 
@@ -234,7 +234,6 @@ PHP;
             '/.box/.requirements.php',
             '/.box/bin/',
             '/.box/bin/check-requirements.php',
-            '/.box/check_requirements.php',
             '/.box/composer.json',
             '/.box/composer.lock',
             '/.box/src/',
@@ -395,7 +394,7 @@ Building the PHAR "/path/to/tmp/index.phar"
 No recommendation found.
 No warning found.
 
- // PHAR: 49 files (100B)
+ // PHAR: 48 files (100B)
  // You can inspect the generated PHAR with the "info" command.
 
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
@@ -436,7 +435,7 @@ OUTPUT;
 
 Phar::mapPhar('box-auto-generated-alias-__uniqid__.phar');
 
-require 'phar://box-auto-generated-alias-__uniqid__.phar/.box/check_requirements.php';
+require 'phar://box-auto-generated-alias-__uniqid__.phar/.box/bin/check-requirements.php';
 
 require 'phar://box-auto-generated-alias-__uniqid__.phar/index.php';
 
@@ -456,7 +455,6 @@ PHP;
             '/.box/.requirements.php',
             '/.box/bin/',
             '/.box/bin/check-requirements.php',
-            '/.box/check_requirements.php',
             '/.box/composer.json',
             '/.box/composer.lock',
             '/.box/src/',
@@ -854,7 +852,7 @@ Private key passphrase:
 No recommendation found.
 No warning found.
 
- // PHAR: 45 files (100B)
+ // PHAR: 44 files (100B)
  // You can inspect the generated PHAR with the "info" command.
 
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
@@ -959,7 +957,7 @@ Private key passphrase:
 No recommendation found.
 No warning found.
 
- // PHAR: 45 files (100B)
+ // PHAR: 44 files (100B)
  // You can inspect the generated PHAR with the "info" command.
 
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
@@ -1089,7 +1087,7 @@ Private key passphrase:
 No recommendation found.
 No warning found.
 
- // PHAR: 45 files (100B)
+ // PHAR: 44 files (100B)
  // You can inspect the generated PHAR with the "info" command.
 
  // Memory usage: 5.00MB (peak: 10.00MB), time: 0.00s
@@ -1111,7 +1109,6 @@ OUTPUT;
         $expectedFiles = [
             '.box_dump/.box/.requirements.php',
             '.box_dump/.box/bin/check-requirements.php',
-            '.box_dump/.box/check_requirements.php',
             '.box_dump/.box/composer.json',
             '.box_dump/.box/composer.lock',
             '.box_dump/.box/src/Checker.php',

--- a/tests/RequirementChecker/RequirementsDumperTest.php
+++ b/tests/RequirementChecker/RequirementsDumperTest.php
@@ -39,7 +39,6 @@ class RequirementsDumperTest extends TestCase
         $expectedFiles = [
             '.requirements.php',
             'bin/check-requirements.php',
-            'check_requirements.php',
             'composer.json',
             'composer.lock',
             'src/Checker.php',

--- a/tests/StubGeneratorTest.php
+++ b/tests/StubGeneratorTest.php
@@ -48,7 +48,7 @@ class StubGeneratorTest extends TestCase
         $expected = <<<'STUB'
 <?php
 
-require 'phar://' . __FILE__ . '/.box/check_requirements.php';
+require 'phar://' . __FILE__ . '/.box/bin/check-requirements.php';
 
 __HALT_COMPILER(); ?>
 
@@ -94,7 +94,7 @@ TEXT
  * Yolo
  */
 
-require 'phar://' . __FILE__ . '/.box/check_requirements.php';
+require 'phar://' . __FILE__ . '/.box/bin/check-requirements.php';
 
 __HALT_COMPILER(); ?>
 
@@ -132,7 +132,7 @@ STUB;
 #!/usr/local/bin/env php
 <?php
 
-require 'phar://' . __FILE__ . '/.box/check_requirements.php';
+require 'phar://' . __FILE__ . '/.box/bin/check-requirements.php';
 
 __HALT_COMPILER(); ?>
 
@@ -164,7 +164,7 @@ STUB;
         $expected = <<<'STUB'
 <?php
 
-require 'phar://' . __FILE__ . '/.box/check_requirements.php';
+require 'phar://' . __FILE__ . '/.box/bin/check-requirements.php';
 
 __HALT_COMPILER(); ?>
 
@@ -197,7 +197,7 @@ STUB;
 
 Phar::mapPhar('acme.phar');
 
-require 'phar://acme.phar/.box/check_requirements.php';
+require 'phar://acme.phar/.box/bin/check-requirements.php';
 
 __HALT_COMPILER(); ?>
 
@@ -228,7 +228,7 @@ STUB;
         $expected = <<<'STUB'
 <?php
 
-require 'phar://' . __FILE__ . '/.box/check_requirements.php';
+require 'phar://' . __FILE__ . '/.box/bin/check-requirements.php';
 
 __HALT_COMPILER(); ?>
 
@@ -259,7 +259,7 @@ STUB;
         $expected = <<<'STUB'
 <?php
 
-require 'phar://' . __FILE__ . '/.box/check_requirements.php';
+require 'phar://' . __FILE__ . '/.box/bin/check-requirements.php';
 
 require 'phar://' . __FILE__ . '/acme.php';
 
@@ -294,7 +294,7 @@ STUB;
 
 Phar::interceptFileFuncs();
 
-require 'phar://' . __FILE__ . '/.box/check_requirements.php';
+require 'phar://' . __FILE__ . '/.box/bin/check-requirements.php';
 
 __HALT_COMPILER(); ?>
 
@@ -348,7 +348,7 @@ TEXT
 Phar::mapPhar('test.phar');
 Phar::interceptFileFuncs();
 
-require 'phar://test.phar/.box/check_requirements.php';
+require 'phar://test.phar/.box/bin/check-requirements.php';
 
 require 'phar://test.phar/index.php';
 


### PR DESCRIPTION
Closes #253.

It seems there is an issue with the `.box/check_requirements.php` file because points to
`.box/bin/check-requirements` but without giving a prefix to the path. In any case that file looks
redundant so has been removed in favour of including `.box/bin/check-requirements.php` directly.