### PR TITLE
Fixed dumping the PHAR contents and restoring the file limit

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -52,8 +52,6 @@ use function sprintf;
  */
 final class Box implements Countable
 {
-    public const DEBUG_DIR = '.box_dump';
-
     /**
      * @var string The path to the PHAR file
      */

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -48,14 +48,11 @@ use function str_replace;
 use function strlen;
 use function substr;
 
-///**
-// * @covers \KevinGH\Box\Console\Command\Compile
-// * @covers \KevinGH\Box\Console\MessageRenderer
-// * @runTestsInSeparateProcesses This is necessary as instantiating a PHAR in memory may load/autoload some stuff which
-// *                              can create undesirable side-effects.
-// */
 /**
- * @coversNothing
+ * @covers \KevinGH\Box\Console\Command\Compile
+ * @covers \KevinGH\Box\Console\MessageRenderer
+ * @runTestsInSeparateProcesses This is necessary as instantiating a PHAR in memory may load/autoload some stuff which
+ *                              can create undesirable side-effects.
  */
 class CompileTest extends CommandTestCase
 {


### PR DESCRIPTION
- The file descriptor limit was being restored although it had not been changed
- The dumped content of the PHAR for debugging purposes was the content directly extracted from the PHAR. However, if the PHAR was being compressed, it was not uncompressing the dumped content causing the dumped files to appear as binaries. The PHAR content is now dumped before the PHAR is being compressed