### PR TITLE
Fix the processing of files

### DIFF
--- a/tests/Console/Command/ProcessTest.php
+++ b/tests/Console/Command/ProcessTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Command\Command;
 use function KevinGH\Box\FileSystem\dump_file;
 use function KevinGH\Box\FileSystem\touch;
 use function preg_replace;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @covers \KevinGH\Box\Console\Command\Process
@@ -34,7 +35,7 @@ class ProcessTest extends CommandTestCase
         return new Process();
     }
 
-    public function test_it_process_a_file_and_displays_the_processed_contents_with_no_config(): void
+    public function test_it_processes_a_file_and_displays_the_processed_contents_with_no_config(): void
     {
         dump_file('index.php', '');
 
@@ -71,7 +72,7 @@ OUTPUT;
         $this->assertSame(0, $this->commandTester->getStatusCode());
     }
 
-    public function test_it_process_a_file_and_displays_the_processed_contents_with_a_config(): void
+    public function test_it_processes_a_file_and_displays_the_processed_contents_with_a_config(): void
     {
         touch('index.php');
         dump_file(
@@ -130,6 +131,148 @@ Processed contents:
 """
 {"foo":"bar"}
 """
+
+OUTPUT;
+
+        $this->assertSame($expected, $actual);
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+    }
+
+    public function test_it_processes_the_file_relative_to_the_config_base_path(): void
+    {
+        dump_file(
+            'index.php',
+            <<<'PHP'
+<?php
+
+echo 'Hello world!';
+PHP
+        );
+
+        dump_file(
+            'box.json',
+            <<<'JSON'
+{
+    "replacements": {
+        "foo": "bar"
+    },
+    "compactors": [
+        "KevinGH\\Box\\Compactor\\PhpScoper"
+    ]
+}
+JSON
+        );
+        dump_file(
+            'scoper.inc.php',
+            <<<'PHP'
+<?php
+
+return [
+    'prefix' => '_Prefix',
+    'patchers' => [
+        function (string $filePath, string $prefix, string $contents): string {
+            if ('index.php' !== $filePath) {
+                return $contents;
+            }
+
+            return str_replace('Hello world!', '!dlrow olleH', $contents);
+        },
+    ],
+];
+
+PHP
+        );
+
+        $this->commandTester->execute(
+            [
+                'command' => 'process',
+                'file' => $this->tmp.'/index.php',
+            ]
+        );
+        $actual = DisplayNormalizer::removeTrailingSpaces($this->commandTester->getDisplay(true));
+
+        $actual = preg_replace(
+            '/\s\/\/ Loading the configuration file([\s\S]*)box\.json[comment\<\>\n\s\/]*"\./',
+            ' // Loading the configuration file "box.json".',
+            $actual
+        );
+
+        $expectedPath = $this->tmp.'/index.php';
+
+        $expected = <<<OUTPUT
+
+
+ // Loading the configuration file "box.json".
+
+⚡  Processing the contents of the file $expectedPath
+
+Registered replacement values:
+  + @foo@: bar
+
+Registered compactors:
+  + KevinGH\Box\Compactor\PhpScoper
+
+Processed contents:
+
+"""
+<?php
+
+namespace _Prefix;
+
+echo '!dlrow olleH';
+
+"""
+
+OUTPUT;
+
+        $this->assertSame($expected, $actual);
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+    }
+
+
+
+    public function test_it_processes_a_file_and_displays_only_the_processed_contents_in_quiet_mode(): void
+    {
+        touch('index.php');
+        dump_file(
+            'acme.json',
+            <<<'JSON'
+{
+    "foo": "@foo@"
+}
+JSON
+        );
+        dump_file(
+            'box.json',
+            <<<'JSON'
+{
+    "replacements": {
+        "foo": "bar"
+    },
+    "compactors": [
+        "KevinGH\\Box\\Compactor\\Json"
+    ]
+}
+JSON
+        );
+
+        $this->commandTester->execute(
+            [
+                'command' => 'process',
+                'file' => 'acme.json',
+            ],
+            ['verbosity' => OutputInterface::VERBOSITY_QUIET]
+        );
+        $actual = DisplayNormalizer::removeTrailingSpaces($this->commandTester->getDisplay(true));
+
+        $actual = preg_replace(
+            '/\s\/\/ Loading the configuration file([\s\S]*)box\.json[comment\<\>\n\s\/]*"\./',
+            ' // Loading the configuration file "box.json".',
+            $actual
+        );
+
+        $expected = <<<'OUTPUT'
+{"foo":"bar"}
 
 OUTPUT;
 


### PR DESCRIPTION
When running the `process` command, the file path provided to the compactors was the absolute path whereas the `Box` class provides the relative path. This was causing issues with the PHP-Scoper
patchers since one will likely expect the relative path and not account for the path to be absolute.
To avoid extra unintuitive work to the user, the relative path is provided as during a regular
compilation.

When running the `process` command with a `quiet` verbosity, only the processed file contents will
be outputed. This allows one to easily copy the processed file contents.