### PR TITLE
Fix the validate command

### DIFF
--- a/src/Console/Command/Command.php
+++ b/src/Console/Command/Command.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace KevinGH\Box\Console\Command;
+
+use KevinGH\Box\Console\Application;
+use KevinGH\Box\Console\ConfigurationHelper;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+
+/**
+ * Tiny Symfony Command adapter to allow the command to easily access to the typehinted helpers which are configured
+ * in the application.
+ *
+ * @see Application
+ */
+abstract class Command extends SymfonyCommand
+{
+    final protected function getConfigurationHelper(): ConfigurationHelper
+    {
+        return $this->getHelper('config');
+    }
+}

--- a/src/Console/Command/Diff.php
+++ b/src/Console/Command/Diff.php
@@ -18,7 +18,6 @@ use Assert\Assertion;
 use KevinGH\Box\PhpSettingsHandler;
 use ParagonIE\Pharaoh\Pharaoh;
 use ParagonIE\Pharaoh\PharDiff;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Console/Command/Info.php
+++ b/src/Console/Command/Info.php
@@ -20,7 +20,6 @@ use Phar;
 use PharData;
 use PharFileInfo;
 use RecursiveIteratorIterator;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Console/Command/Validate.php
+++ b/src/Console/Command/Validate.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace KevinGH\Box\Console\Command;
 
 use Exception;
+use KevinGH\Box\Console\ConfigurationLoader;
 use KevinGH\Box\Console\MessageRenderer;
 use KevinGH\Box\Console\OutputConfigurator;
 use KevinGH\Box\Json\JsonValidationException;
@@ -29,8 +30,9 @@ use function sprintf;
 /**
  * @private
  */
-final class Validate extends ConfigurableCommand
+final class Validate extends Command
 {
+    private const FILE_ARGUMENT = 'file';
     private const IGNORE_MESSAGES_OPTION = 'ignore-recommendations-and-warnings';
 
     /**
@@ -56,7 +58,7 @@ and report any errors found, if any.
 HELP
         );
         $this->addArgument(
-            'file',
+            self::FILE_ARGUMENT,
             InputArgument::OPTIONAL,
             'The configuration file. (default: box.json, box.json.dist)'
         );
@@ -78,7 +80,12 @@ HELP
         OutputConfigurator::configure($output);
 
         try {
-            $config = $this->getConfig($input, $output);
+            $config = ConfigurationLoader::getConfig(
+                $input->getArgument(self::FILE_ARGUMENT) ?? $this->getConfigurationHelper()->findDefaultPath(),
+                $this->getConfigurationHelper(),
+                new SymfonyStyle($input, $output),
+                false
+            );
 
             $recommendations = $config->getRecommendations();
             $warnings = $config->getWarnings();

--- a/src/Console/Command/Verify.php
+++ b/src/Console/Command/Verify.php
@@ -16,7 +16,6 @@ namespace KevinGH\Box\Console\Command;
 
 use Assert\Assertion;
 use Phar;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Console/ConfigurationLoader.php
+++ b/src/Console/ConfigurationLoader.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace KevinGH\Box\Console;
+
+use InvalidArgumentException;
+use KevinGH\Box\Configuration;
+use KevinGH\Box\Json\JsonValidationException;
+use KevinGH\Box\NoConfigurationFound;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use function sprintf;
+
+/**
+ * @private
+ */
+final class ConfigurationLoader
+{
+    /**
+     * Returns the configuration settings.
+     *
+     * @param bool $allowNoFile Load the config nonetheless if not file is found when true
+     *
+     * @throws JsonValidationException
+     */
+    public static function getConfig(
+        ?string $configPath,
+        ConfigurationHelper $helper,
+        SymfonyStyle $io,
+        bool $allowNoFile
+    ): Configuration {
+        try {
+            $configPath = $configPath ?? $helper->findDefaultPath();
+
+            $io->comment(
+                sprintf(
+                    'Loading the configuration file "<comment>%s</comment>".',
+                    $configPath
+                )
+            );
+        } catch (NoConfigurationFound $exception) {
+            if (false === $allowNoFile) {
+                throw $exception;
+            }
+
+            $io->comment('Loading without a configuration file.');
+
+            $configPath = null;
+        }
+
+        try {
+            return $helper->loadFile($configPath);
+        } catch (InvalidArgumentException $exception) {
+            $io->error('The configuration file is invalid.');
+
+            throw $exception;
+        }
+    }
+}

--- a/tests/Console/Command/ValidateTest.php
+++ b/tests/Console/Command/ValidateTest.php
@@ -47,7 +47,7 @@ class ValidateTest extends CommandTestCase
         $this->commandTester->execute(
             [
                 'command' => 'validate',
-                '--config' => 'test.json',
+                'file' => 'test.json',
             ],
             [
                 'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
@@ -85,7 +85,7 @@ JSON
         $this->commandTester->execute(
             [
                 'command' => 'validate',
-                '--config' => 'test.json',
+                'file' => 'test.json',
             ],
             [
                 'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
@@ -124,7 +124,7 @@ JSON
         $this->commandTester->execute(
             [
                 'command' => 'validate',
-                '--config' => 'test.json',
+                'file' => 'test.json',
                 '--ignore-recommendations-and-warnings' => null,
             ],
             [
@@ -164,7 +164,7 @@ JSON
         $this->commandTester->execute(
             [
                 'command' => 'validate',
-                '--config' => 'test.json',
+                'file' => 'test.json',
             ],
             [
                 'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
@@ -203,7 +203,7 @@ JSON
         $this->commandTester->execute(
             [
                 'command' => 'validate',
-                '--config' => 'test.json',
+                'file' => 'test.json',
                 '--ignore-recommendations-and-warnings' => null,
             ],
             [
@@ -243,7 +243,7 @@ JSON
         $this->commandTester->execute(
             [
                 'command' => 'validate',
-                '--config' => 'test.json',
+                'file' => 'test.json',
             ],
             [
                 'verbosity' => OutputInterface::VERBOSITY_VERBOSE,


### PR DESCRIPTION
No longer make `Validate` extend `ConfigurableCommand` since the configuration file is an argument
and the argument should be used instead of the option.

The validate command now properly takes the argument given instead of relying on the default find
found in the current working directory or the file passed via the configuration option.