### PR TITLE
Fix the dump autoloader related issues

### DIFF
--- a/fixtures/configuration/dir003/box.json
+++ b/fixtures/configuration/dir003/box.json
@@ -3,5 +3,6 @@
     "directories": [
         "src/",
         "vendor/beberlei/"
-    ]
+    ],
+    "dump-autoload": true
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -263,7 +263,7 @@ BANNER;
 
         $composerFiles = self::retrieveComposerFiles($basePath);
 
-        $dumpAutoload = self::retrieveDumpAutoload($raw, null !== $composerFiles->getComposerJson()->getPath(), $logger);
+        $dumpAutoload = self::retrieveDumpAutoload($raw, $composerFiles, $logger);
 
         if ($dumpAutoload && null !== $composerFiles->getInstalledJson()->getPath() && null === $composerFiles->getComposerLock()->getPath()) {
             $logger->addWarning(
@@ -1051,32 +1051,11 @@ BANNER;
                 // Avoid an array_merge here as it can be quite expansive at this stage depending of the number of files
                 $files[] = $filesFromFinder;
             }
+
+            $files[] = self::wrapInSplFileInfo($composerFiles->getPaths());
         }
 
-        $aggregate = self::retrieveFilesAggregate(...$files);
-
-        if (false === $dumpAutoload) {
-            return $aggregate;
-        }
-
-        if (null === $composerFiles->getComposerLock()->getPath()) {
-            return $aggregate;
-        }
-
-        foreach ($aggregate as $file) {
-            if ($file->getRealPath() === $composerFiles->getInstalledJson()->getPath()) {
-                return $aggregate;
-            }
-        }
-
-        $logger->addWarning(
-            'A composer.lock file has been found but its related file vendor/composer/installed.json could not. This '
-            .'could be due to either dependencies incorrectly installed or an incorrect Box configuration which is not '
-            .'including the installed.json file. This will not break the build but will likely result in a broken '
-            .'Composer classmap.'
-        );
-
-        return $aggregate;
+        return self::retrieveFilesAggregate(...$files);
     }
 
     /**
@@ -1728,27 +1707,69 @@ BANNER;
         );
     }
 
-    private static function retrieveDumpAutoload(stdClass $raw, bool $composerJson, ConfigurationLogger $logger): bool
+    private static function retrieveDumpAutoload(stdClass $raw, ComposerFiles $composerFiles, ConfigurationLogger $logger): bool
     {
-        self::checkIfDefaultValue($logger, $raw, self::DUMP_AUTOLOAD_KEY, true);
+//        $composerJson = null !== $composerFiles->getComposerJson()->getPath();
+//
+//        self::checkIfDefaultValue($logger, $raw, self::DUMP_AUTOLOAD_KEY, true);
+//
+//        if (false === property_exists($raw, self::DUMP_AUTOLOAD_KEY)) {
+//            return $composerJson;
+//        }
+//
+//        $dumpAutoload = $raw->{self::DUMP_AUTOLOAD_KEY} ?? true;
+//
+//        if (false === $composerJson && $dumpAutoload) {
+//            // TODO: use sprintf there; check other occurrences as well
+//            $logger->addWarning(
+//                'The "dump-autoload" setting has been set but has been ignored because the composer.json file necessary'
+//                .' for it could not be found'
+//            );
+//
+//            return false;
+//        }
+//
+//        return $composerJson && false !== $dumpAutoload;
+
+        self::checkIfDefaultValue($logger, $raw, self::DUMP_AUTOLOAD_KEY, null);
+
+        $canDumpAutoload = (
+            null !== $composerFiles->getComposerJson()->getPath()
+            && (
+                // The composer.lock and installed.json are optional (e.g. if there is no dependencies installed)
+                // but when one is present, the other must be as well otherwise the dumped autoloader will be broken
+                (
+                    null === $composerFiles->getComposerLock()->getPath()
+                    && null === $composerFiles->getInstalledJson()->getPath()
+                )
+                || (
+                    null !== $composerFiles->getComposerLock()->getPath()
+                    && null !== $composerFiles->getInstalledJson()->getPath()
+                )
+            )
+        );
+
+        if ($canDumpAutoload) {
+            self::checkIfDefaultValue($logger, $raw, self::DUMP_AUTOLOAD_KEY, true);
+        }
 
         if (false === property_exists($raw, self::DUMP_AUTOLOAD_KEY)) {
-            return $composerJson;
+            return $canDumpAutoload;
         }
 
         $dumpAutoload = $raw->{self::DUMP_AUTOLOAD_KEY} ?? true;
 
-        if (false === $composerJson && $dumpAutoload) {
+        if (false === $canDumpAutoload && $dumpAutoload) {
             // TODO: use sprintf there; check other occurrences as well
             $logger->addWarning(
-                'The "dump-autoload" setting has been set but has been ignored because the composer.json file necessary'
-                .' for it could not be found'
+                'The "dump-autoload" setting has been set but has been ignored because the composer.json, composer.lock'
+                .' and vendor/composer/installed.json files are necessary but could not be found.'
             );
 
             return false;
         }
 
-        return $composerJson && false !== $dumpAutoload;
+        return $canDumpAutoload && false !== $dumpAutoload;
     }
 
     private static function retrieveExcludeDevFiles(stdClass $raw, bool $dumpAutoload, ConfigurationLogger $logger): bool

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -265,14 +265,6 @@ BANNER;
 
         $dumpAutoload = self::retrieveDumpAutoload($raw, $composerFiles, $logger);
 
-        if ($dumpAutoload && null !== $composerFiles->getInstalledJson()->getPath() && null === $composerFiles->getComposerLock()->getPath()) {
-            $logger->addWarning(
-                'A vendor/composer/installed.json file has been found but its related file composer.lock could not. '
-                .'This is likely due to the file having been removed despite being necessary. This will not break the '
-                .'build but the dump-autoload had to be disabled.'
-            );
-        }
-
         $excludeComposerFiles = self::retrieveExcludeComposerFiles($raw, $logger);
 
         $mainScriptPath = self::retrieveMainScriptPath($raw, $basePath, $composerFiles->getComposerJson()->getDecodedContents(), $logger);
@@ -1709,28 +1701,6 @@ BANNER;
 
     private static function retrieveDumpAutoload(stdClass $raw, ComposerFiles $composerFiles, ConfigurationLogger $logger): bool
     {
-//        $composerJson = null !== $composerFiles->getComposerJson()->getPath();
-//
-//        self::checkIfDefaultValue($logger, $raw, self::DUMP_AUTOLOAD_KEY, true);
-//
-//        if (false === property_exists($raw, self::DUMP_AUTOLOAD_KEY)) {
-//            return $composerJson;
-//        }
-//
-//        $dumpAutoload = $raw->{self::DUMP_AUTOLOAD_KEY} ?? true;
-//
-//        if (false === $composerJson && $dumpAutoload) {
-//            // TODO: use sprintf there; check other occurrences as well
-//            $logger->addWarning(
-//                'The "dump-autoload" setting has been set but has been ignored because the composer.json file necessary'
-//                .' for it could not be found'
-//            );
-//
-//            return false;
-//        }
-//
-//        return $composerJson && false !== $dumpAutoload;
-
         self::checkIfDefaultValue($logger, $raw, self::DUMP_AUTOLOAD_KEY, null);
 
         $canDumpAutoload = (
@@ -1745,6 +1715,11 @@ BANNER;
                 || (
                     null !== $composerFiles->getComposerLock()->getPath()
                     && null !== $composerFiles->getInstalledJson()->getPath()
+                )
+                || (
+                    null === $composerFiles->getComposerLock()->getPath()
+                    && null !== $composerFiles->getInstalledJson()->getPath()
+                    && [] === $composerFiles->getInstalledJson()->getDecodedContents()
                 )
             )
         );

--- a/tests/ConfigurationFileTest.php
+++ b/tests/ConfigurationFileTest.php
@@ -1769,6 +1769,8 @@ JSON
     {
         $config = Configuration::create($configPath = self::FIXTURES_DIR.'/dir001/box.json', json_decode(get_contents($configPath)));
 
+        $this->assertTrue($config->dumpAutoload());
+
         $this->assertSame([], $config->getRecommendations());
         $this->assertSame([], $config->getWarnings());
     }
@@ -1776,6 +1778,8 @@ JSON
     public function test_no_warning_is_given_when_the_installed_json_is_found_and_the_composer_lock_is_not_when_the_composer_autoloader_is_not_dumped(): void
     {
         $config = Configuration::create($configPath = self::FIXTURES_DIR.'/dir002/box.json', json_decode(get_contents($configPath)));
+
+        $this->assertFalse($config->dumpAutoload());
 
         $this->assertSame([], $config->getRecommendations());
         $this->assertSame([], $config->getWarnings());
@@ -1787,6 +1791,8 @@ JSON
         $decodedConfig->{'dump-autoload'} = true;
 
         $config = Configuration::create($configPath, $decodedConfig);
+
+        $this->assertFalse($config->dumpAutoload());
 
         $this->assertSame([], $config->getRecommendations());
         $this->assertSame(
@@ -1807,6 +1813,8 @@ JSON
 
         $config = Configuration::create($configPath, $decodedConfig);
 
+        $this->assertFalse($config->dumpAutoload());
+
         $this->assertSame([], $config->getRecommendations());
         $this->assertSame([], $config->getWarnings());
     }
@@ -1814,6 +1822,8 @@ JSON
     public function test_a_warning_is_given_when_the_installed_json_is_found_and_the_composer_lock_is_not(): void
     {
         $config = Configuration::create($configPath = self::FIXTURES_DIR.'/dir003/box.json', json_decode(get_contents($configPath)));
+
+        $this->assertFalse($config->dumpAutoload());
 
         $this->assertSame([], $config->getRecommendations());
         $this->assertSame(
@@ -1825,9 +1835,11 @@ JSON
         );
     }
 
-    public function test_not_warning_is_given_when_the_installed_json_is_found_and_the_composer_lock_is_not_and_the_dump_autoload_disabled(): void
+    public function test_no_warning_is_given_when_the_installed_json_is_found_and_the_composer_lock_is_not_and_the_dump_autoload_disabled(): void
     {
         $config = Configuration::create($configPath = self::FIXTURES_DIR.'/dir004/box.json', json_decode(get_contents($configPath)));
+
+        $this->assertFalse($config->dumpAutoload());
 
         $this->assertSame([], $config->getRecommendations());
         $this->assertSame([], $config->getWarnings());

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -344,19 +344,7 @@ EOF
         $this->assertSame($expectedLockContents, $this->config->getDecodedComposerLockContents());
 
         $this->assertSame([], $this->config->getRecommendations());
-
-        $ignoredWarnings = [
-            'A composer.lock file has been found but its related file vendor/composer/installed.json'
-            .'could not. This could be due to either dependencies incorrectly installed or an incorrect Box '
-            .'configuration which is not including the installed.json file. This will not break the build but will '
-            .'likely result in a broken Composer classmap.',
-            'A composer.lock file has been found but its related file vendor/composer/installed.json could not. This '
-            .'could be due to either dependencies incorrectly installed or an incorrect Box configuration which is not '
-            .'including the installed.json file. This will not break the build but will likely result in a broken '
-            .'Composer classmap.',
-        ];
-
-        $this->assertSame([], array_diff($this->config->getWarnings(), $ignoredWarnings));
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_it_throws_an_error_when_a_composer_file_is_found_but_invalid(): void
@@ -423,7 +411,10 @@ EOF
             $this->config->getRecommendations()
         );
         $this->assertSame(
-            ['The "dump-autoload" setting has been set but has been ignored because the composer.json file necessary for it could not be found'],
+            [
+                'The "dump-autoload" setting has been set but has been ignored because the composer.json, composer.lock'
+                .' and vendor/composer/installed.json files are necessary but could not be found.',
+            ],
             $this->config->getWarnings()
         );
 
@@ -481,12 +472,12 @@ EOF
 
         $this->assertFalse($this->config->dumpAutoload());
 
+        $this->assertSame([], $this->config->getRecommendations());
         $this->assertSame(
-            ['The "dump-autoload" setting can be omitted since is set to its default value'],
-            $this->config->getRecommendations()
-        );
-        $this->assertSame(
-            ['The "dump-autoload" setting has been set but has been ignored because the composer.json file necessary for it could not be found'],
+            [
+                'The "dump-autoload" setting has been set but has been ignored because the composer.json, composer.lock'
+                .' and vendor/composer/installed.json files are necessary but could not be found.',
+            ],
             $this->config->getWarnings()
         );
     }
@@ -2524,17 +2515,6 @@ COMMENT;
 
     public function test_the_requirement_checker_is_enabled_by_default_if_a_composer_lock_or_json_file_is_found(): void
     {
-        $ignoredWarnings = [
-            'A composer.lock file has been found but its related file vendor/composer/installed.json'
-            .'could not. This could be due to either dependencies incorrectly installed or an incorrect Box '
-            .'configuration which is not including the installed.json file. This will not break the build but will '
-            .'likely result in a broken Composer classmap.',
-            'A composer.lock file has been found but its related file vendor/composer/installed.json could not. This '
-            .'could be due to either dependencies incorrectly installed or an incorrect Box configuration which is not '
-            .'including the installed.json file. This will not break the build but will likely result in a broken '
-            .'Composer classmap.',
-        ];
-
         $this->assertFalse($this->config->checkRequirements());
 
         dump_file('composer.lock', '{}');
@@ -2544,7 +2524,7 @@ COMMENT;
         $this->assertTrue($this->config->checkRequirements());
 
         $this->assertSame([], $this->config->getRecommendations());
-        $this->assertSame([], array_diff($this->config->getWarnings(), $ignoredWarnings));
+        $this->assertSame([], $this->config->getWarnings());
 
         dump_file('composer.json', '{}');
         remove('composer.lock');
@@ -2554,7 +2534,7 @@ COMMENT;
         $this->assertTrue($this->config->checkRequirements());
 
         $this->assertSame([], $this->config->getRecommendations());
-        $this->assertSame([], array_diff($this->config->getWarnings(), $ignoredWarnings));
+        $this->assertSame([], $this->config->getWarnings());
 
         dump_file('composer.lock', '{}');
 
@@ -2563,7 +2543,7 @@ COMMENT;
         $this->assertTrue($this->config->checkRequirements());
 
         $this->assertSame([], $this->config->getRecommendations());
-        $this->assertSame([], array_diff($this->config->getWarnings(), $ignoredWarnings));
+        $this->assertSame([], $this->config->getWarnings());
     }
 
     public function test_the_requirement_checker_can_be_enabled(): void


### PR DESCRIPTION
- No longer display a message when the user force the `dump-autoload` setting to `true` when the result is that the autoloader cannot be dumped
- Skip dumping the autoloader when once of the `composer.lock` and `vendor/composer/installed.json` file is found but not the other
- Automatically append the composer files even when the auto-discovery is turned off to allow the
  Composer autoloader to be dumped without issues

Closes #368.
Closes #359.