### PR TITLE
Fix the scoping of Amphp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,11 @@ before_install:
     fi
   - set -eo pipefail
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - pecl install ev
+  - php -i | grep ev
   - echo "extension = ev.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - php -i | grep ev
+  - pecl install uv
   - echo "extension = uv.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer validate
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,10 @@ before_install:
     fi
   - set -eo pipefail
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - pecl install ev
+  - echo '' | pecl install ev
   - php -i | grep ev
   - echo "extension = ev.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - php -i | grep ev
+  - echo '' | php -i | grep ev
   - pecl install uv
   - echo "extension = uv.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer validate

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 addons:
   apt:
     packages:
-      - libev
+      - libev.dev
       - libuv.dev
 
 matrix:
@@ -38,7 +38,6 @@ before_install:
         phpenv config-rm xdebug.ini || true
     fi
   - set -eo pipefail
-  - sudo apt-get install -y libxml2-dev
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo "extension = ev.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo "extension = uv.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ env:
 addons:
   apt:
     packages:
-      - libev.dev
-      - libuv.dev
+      - libevent-dev
 
 matrix:
   include:
@@ -39,12 +38,9 @@ before_install:
     fi
   - set -eo pipefail
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - echo '' | pecl install ev
-  - php -i | grep ev
-  - echo "extension = ev.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - echo '' | php -i | grep ev
-  - pecl install uv
-  - echo "extension = uv.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - travis/install-uv.sh
+  - travis/install-ev.sh
+  - travis/install-event.sh
   - composer validate
   - |
     if [ "DEPLOY" != "true" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ before_install:
     fi
   - set -eo pipefail
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - travis/install-uv.sh
-  - travis/install-ev.sh
-  - travis/install-event.sh
+  - .travis/install-uv.sh
+  - .travis/install-ev.sh
+  - .travis/install-event.sh
   - composer validate
   - |
     if [ "DEPLOY" != "true" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
 addons:
   apt:
     packages:
+      - libev
       - libuv.dev
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ cache:
 env:
   - COMPOSER_FLAGS='--no-interaction --no-progress --no-suggest --prefer-dist'
 
+addons:
+  apt:
+    packages:
+      - libev
+      - libuv
+
 matrix:
   include:
     - php: '7.1'
@@ -32,6 +38,7 @@ before_install:
         phpenv config-rm xdebug.ini || true
     fi
   - set -eo pipefail
+  - sudo apt-get install -y libxml2-dev
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo "extension = ev.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo "extension = uv.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ env:
 addons:
   apt:
     packages:
-      - libev
-      - libuv
+      - libuv.dev
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ env:
 matrix:
   include:
     - php: '7.1'
-      env: DEPLOY=true
     - php: '7.2'
     - php: '7.3'
+      env: DEPLOY=true
     - php: '7.3'
       env: PHAR_READONLY='true'
     - php: '7.3'
@@ -33,6 +33,8 @@ before_install:
     fi
   - set -eo pipefail
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "extension = ev.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "extension = uv.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer validate
   - |
     if [ "DEPLOY" != "true" ]; then

--- a/.travis/install-ev.sh
+++ b/.travis/install-ev.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+#
+# Credits: https://github.com/amphp/amp/blob/8283532/travis/install-ev.sh
+#
+
+curl -LS https://pecl.php.net/get/ev | tar -xz;
+pushd ev-*;
+phpize;
+./configure;
+make;
+make install;
+popd;
+echo "extension=ev.so" >> "$(php -r 'echo php_ini_loaded_file();')";

--- a/.travis/install-event.sh
+++ b/.travis/install-event.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+#
+# Credits: https://github.com/amphp/amp/blob/8283532/travis/install-event.sh
+#
+
+curl -LS https://pecl.php.net/get/event-2.3.0 | tar -xz \
+ && pushd event-* \
+ && phpize \
+ && ./configure --with-event-core --with-event-extra --with-event-pthreads \
+ && make \
+ && make install \
+ && popd \
+ && echo "extension=event.so" >> "$(php -r 'echo php_ini_loaded_file();')";

--- a/.travis/install-uv.sh
+++ b/.travis/install-uv.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#
+# Credits: https://github.com/amphp/amp/blob/8283532/travis/install-uv.sh
+#
+
+wget https://github.com/libuv/libuv/archive/v1.x.tar.gz -O /tmp/libuv.tar.gz -q &
+wget https://github.com/bwoebi/php-uv/archive/master.tar.gz -O /tmp/php-uv.tar.gz -q &
+wait
+
+mkdir libuv && tar -xf /tmp/libuv.tar.gz -C libuv --strip-components=1
+mkdir php-uv && tar -xf /tmp/php-uv.tar.gz -C php-uv --strip-components=1
+
+pushd libuv;
+./autogen.sh
+./configure --prefix=$(dirname `pwd`)/libuv-install
+make
+make install
+popd
+
+pushd php-uv
+phpize
+./configure --with-uv=$(dirname `pwd`)/libuv-install
+make
+make install
+popd
+
+echo "extension=uv.so" >> "$(php -r 'echo php_ini_loaded_file();')"

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -356,7 +356,6 @@ BANNER;
             $composerFiles,
             $autodiscoverFiles,
             $forceFilesAutodiscovery,
-            $dumpAutoload,
             $logger
         );
         $binaryFilesAggregate = self::collectBinaryFiles(
@@ -994,7 +993,6 @@ BANNER;
         ComposerFiles $composerFiles,
         bool $autodiscoverFiles,
         bool $forceFilesAutodiscovery,
-        bool $dumpAutoload,
         ConfigurationLogger $logger
     ): array {
         $files = [self::retrieveFiles($raw, self::FILES_KEY, $basePath, $composerFiles, $alwaysExcludedPaths, $logger)];


### PR DESCRIPTION
Closes #380

- Deploy the scoped PHAR from the PHP 7.3 build instead of the 7.1
- Enable the suggested extensions for amphp to ensure the scoping doesn't scope the extension symbols by accident