### PR TITLE
Fix the dump of Symfony environment variables

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -76,7 +76,7 @@ $config = PhpCsFixer\Config::create()
             ->append(['bin/box'])
             ->notName('default_stub.php')
             ->exclude('check-requirements')
-            ->exclude('fixtures/build/dir012/var/cache')
+            ->exclude('fixtures/build/dir012/var')
     )
 ;
 

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ else
 endif
 .PHONY: e2e_php_settings_checker
 e2e_php_settings_checker: ## Runs the end-to-end tests for the PHP settings handler
-e2e_php_settings_checker: vendor
+e2e_php_settings_checker: vendor box
 	./.docker/build
 
 	# No restart needed
@@ -222,7 +222,7 @@ e2e_php_settings_checker: vendor
 		$(BOX_COMPILE) \
 		| grep '\[debug\]' \
 		| tee fixtures/php-settings-checker/actual-output || true
-	$(SED) "s/'-c' '.*' 'bin\/box'/'-c' '\/tmp-file' 'bin\/box'/" \
+	$(SED) "s/'-c' '.*' '\.\/box'/'-c' '\/tmp-file' 'bin\/box'/" \
 		fixtures/php-settings-checker/actual-output
 	$(SED) "s/[0-9]* ms/100 ms/" fixtures/php-settings-checker/actual-output
 	diff fixtures/php-settings-checker/output-xdebug-enabled fixtures/php-settings-checker/actual-output
@@ -233,7 +233,7 @@ e2e_php_settings_checker: vendor
 		$(BOX_COMPILE) \
 		| grep '\[debug\]' \
 		| tee fixtures/php-settings-checker/actual-output || true
-	$(SED) "s/'-c' '.*' 'bin\/box'/'-c' '\/tmp-file' 'bin\/box'/" fixtures/php-settings-checker/actual-output
+	$(SED) "s/'-c' '.*' '\.\/box'/'-c' '\/tmp-file' 'bin\/box'/" fixtures/php-settings-checker/actual-output
 	$(SED) "s/[0-9]* ms/100 ms/" fixtures/php-settings-checker/actual-output
 	diff fixtures/php-settings-checker/output-pharreadonly-enabled fixtures/php-settings-checker/actual-output
 
@@ -243,7 +243,7 @@ e2e_php_settings_checker: vendor
 		$(BOX_COMPILE) \
 		| grep '\[debug\]' \
 		| tee fixtures/php-settings-checker/actual-output || true
-	$(SED) "s/'-c' '.*' 'bin\/box'/'-c' '\/tmp-file' 'bin\/box'/" fixtures/php-settings-checker/actual-output
+	$(SED) "s/'-c' '.*' '\.\/box'/'-c' '\/tmp-file' 'bin\/box'/" fixtures/php-settings-checker/actual-output
 	$(SED) "s/[0-9]* ms/100 ms/" fixtures/php-settings-checker/actual-output
 	diff fixtures/php-settings-checker/output-min-memory-limit fixtures/php-settings-checker/actual-output
 
@@ -253,7 +253,7 @@ e2e_php_settings_checker: vendor
 		$(BOX_COMPILE) \
 		| grep '\[debug\]' \
 		| tee fixtures/php-settings-checker/actual-output || true
-	$(SED) "s/'-c' '.*' 'bin\/box'/'-c' '\/tmp-file' 'bin\/box'/" fixtures/php-settings-checker/actual-output
+	$(SED) "s/'-c' '.*' '\.\/box'/'-c' '\/tmp-file' 'bin\/box'/" fixtures/php-settings-checker/actual-output
 	$(SED) "s/[0-9]* ms/100 ms/" fixtures/php-settings-checker/actual-output
 	diff fixtures/php-settings-checker/output-set-memory-limit fixtures/php-settings-checker/actual-output
 

--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ e2e_symfony: fixtures/build/dir012/vendor box
 	APP_ENV=prod APP_DEBUG=0 php fixtures/build/dir012/bin/console --version > fixtures/build/dir012/expected-output
 	rm -rf fixtures/build/dir012/var/cache/prod/*
 
-	APP_ENV=prod APP_DEBUG=0 $(BOX) compile --working-dir fixtures/build/dir012
+	APP_ENV=prod APP_DEBUG=0 ./box compile --working-dir fixtures/build/dir012
 
 	php fixtures/build/dir012/bin/console.phar --version > fixtures/build/dir012/actual-output
 

--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ e2e_php_settings_checker: vendor
 .PHONY: e2e_symfony
 e2e_symfony:		 ## Packages a fresh Symfony app
 e2e_symfony: fixtures/build/dir012/vendor box
-	composer dump-env prod
+	composer dump-env prod --working-dir fixtures/build/dir012
 
 	APP_ENV=prod APP_DEBUG=0 php fixtures/build/dir012/bin/console --version > fixtures/build/dir012/expected-output
 	rm -rf fixtures/build/dir012/var/cache/prod/*

--- a/TODO
+++ b/TODO
@@ -1,0 +1,1 @@
+Add OS version info in metadata like done in Composer

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ext-phar": "*",
         "amphp/parallel-functions": "^0.1.2",
         "beberlei/assert": "^3.0",
-        "composer/composer": "^1.6",
+        "composer/semver": "^1.5",
         "composer/xdebug-handler": "^1.1.0",
         "hoa/compiler": "^3.17",
         "humbug/php-scoper": "^0.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "975e1277eaf7e574bf22341de02c0ddf",
+    "content-hash": "a43ff4593ac800cde76393ff13c61172",
     "packages": [
         {
             "name": "amphp/amp",
@@ -469,153 +469,17 @@
             "time": "2018-12-24T15:25:25+00:00"
         },
         {
-            "name": "composer/ca-bundle",
-            "version": "1.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "558f321c52faeb4828c03e7dc0cfe39a09e09a2d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/558f321c52faeb4828c03e7dc0cfe39a09e09a2d",
-                "reference": "558f321c52faeb4828c03e7dc0cfe39a09e09a2d",
-                "shasum": ""
-            },
-            "require": {
-                "ext-openssl": "*",
-                "ext-pcre": "*",
-                "php": "^5.3.2 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
-                "psr/log": "^1.0",
-                "symfony/process": "^2.5 || ^3.0 || ^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\CaBundle\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
-            "keywords": [
-                "cabundle",
-                "cacert",
-                "certificate",
-                "ssl",
-                "tls"
-            ],
-            "time": "2019-01-28T09:30:10+00:00"
-        },
-        {
-            "name": "composer/composer",
-            "version": "1.8.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/composer.git",
-                "reference": "bc364c2480c17941e2135cfc568fa41794392534"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/bc364c2480c17941e2135cfc568fa41794392534",
-                "reference": "bc364c2480c17941e2135cfc568fa41794392534",
-                "shasum": ""
-            },
-            "require": {
-                "composer/ca-bundle": "^1.0",
-                "composer/semver": "^1.0",
-                "composer/spdx-licenses": "^1.2",
-                "composer/xdebug-handler": "^1.1",
-                "justinrainbow/json-schema": "^3.0 || ^4.0 || ^5.0",
-                "php": "^5.3.2 || ^7.0",
-                "psr/log": "^1.0",
-                "seld/jsonlint": "^1.4",
-                "seld/phar-utils": "^1.0",
-                "symfony/console": "^2.7 || ^3.0 || ^4.0",
-                "symfony/filesystem": "^2.7 || ^3.0 || ^4.0",
-                "symfony/finder": "^2.7 || ^3.0 || ^4.0",
-                "symfony/process": "^2.7 || ^3.0 || ^4.0"
-            },
-            "conflict": {
-                "symfony/console": "2.8.38"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7",
-                "phpunit/phpunit-mock-objects": "^2.3 || ^3.0"
-            },
-            "suggest": {
-                "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
-                "ext-zip": "Enabling the zip extension allows you to unzip archives",
-                "ext-zlib": "Allow gzip compression of HTTP requests"
-            },
-            "bin": [
-                "bin/composer"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.8-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\": "src/Composer"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Composer helps you declare, manage and install dependencies of PHP projects, ensuring you have the right stack everywhere.",
-            "homepage": "https://getcomposer.org/",
-            "keywords": [
-                "autoload",
-                "dependency",
-                "package"
-            ],
-            "time": "2019-02-11T09:52:10+00:00"
-        },
-        {
             "name": "composer/semver",
-            "version": "1.4.2",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
+                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
-                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "url": "https://api.github.com/repos/composer/semver/zipball/46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
+                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
                 "shasum": ""
             },
             "require": {
@@ -664,68 +528,7 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2016-08-30T16:08:34+00:00"
-        },
-        {
-            "name": "composer/spdx-licenses",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "7a9556b22bd9d4df7cad89876b00af58ef20d3a2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/7a9556b22bd9d4df7cad89876b00af58ef20d3a2",
-                "reference": "7a9556b22bd9d4df7cad89876b00af58ef20d3a2",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
-                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Spdx\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "SPDX licenses list and validation library.",
-            "keywords": [
-                "license",
-                "spdx",
-                "validator"
-            ],
-            "time": "2018-11-01T09:45:54+00:00"
+            "time": "2019-03-19T17:25:45+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -2590,50 +2393,6 @@
             "time": "2018-01-24T12:46:19+00:00"
         },
         {
-            "name": "seld/phar-utils",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/phar-utils.git",
-                "reference": "7009b5139491975ef6486545a39f3e6dad5ac30a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/7009b5139491975ef6486545a39f3e6dad5ac30a",
-                "reference": "7009b5139491975ef6486545a39f3e6dad5ac30a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Seld\\PharUtils\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
-                }
-            ],
-            "description": "PHAR file format utilities, for when PHP phars you up",
-            "keywords": [
-                "phra"
-            ],
-            "time": "2015-10-13T18:44:15+00:00"
-        },
-        {
             "name": "symfony/console",
             "version": "v4.2.4",
             "source": {
@@ -3352,6 +3111,62 @@
                 "MIT"
             ],
             "time": "2017-09-11T13:13:58+00:00"
+        },
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "558f321c52faeb4828c03e7dc0cfe39a09e09a2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/558f321c52faeb4828c03e7dc0cfe39a09e09a2d",
+                "reference": "558f321c52faeb4828c03e7dc0cfe39a09e09a2d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
+                "psr/log": "^1.0",
+                "symfony/process": "^2.5 || ^3.0 || ^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "time": "2019-01-28T09:30:10+00:00"
         },
         {
             "name": "doctrine/instantiator",

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -160,6 +160,8 @@ return [
         __DIR__.'/vendor/composer/composer/src/Composer/Autoload/ClassLoader.php',
     ],
     'whitelist' => [
+        'Composer\*',
+
         \Composer\Autoload\ClassLoader::class,
 
         \Herrera\Box\Compactor\Json::class,

--- a/src/Composer/ComposerOrchestrator.php
+++ b/src/Composer/ComposerOrchestrator.php
@@ -29,6 +29,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
+use function trim;
 
 /**
  * @private
@@ -132,7 +133,7 @@ final class ComposerOrchestrator
 
         if (false === $dumpAutoloadProcess->isSuccessful()) {
             throw new RuntimeException(
-                'Could not dump the autoload',
+                'Could not dump the autoloader.',
                 0,
                 new ProcessFailedException($dumpAutoloadProcess)
             );
@@ -153,6 +154,6 @@ final class ComposerOrchestrator
             new ProcessFailedException($vendorDirProcess);
         }
 
-        return $vendorDirProcess->getOutput();
+        return trim($vendorDirProcess->getOutput()).'/autoload.php';
     }
 }

--- a/tests/BoxTest.php
+++ b/tests/BoxTest.php
@@ -742,12 +742,17 @@ class BoxTest extends FileSystemTestCase
 
             $this->fail('Expected exception to be thrown.');
         } catch (RuntimeException $exception) {
-            $this->assertStringStartsWith(
-                'Could not dump the autoload: Composer could not find a composer.json file in',
+            $this->assertSame(
+                'Could not dump the autoloader.',
                 $exception->getMessage()
             );
             $this->assertSame(0, $exception->getCode());
             $this->assertNotNull($exception->getPrevious());
+
+            $this->assertStringContainsString(
+                'Composer could not find a composer.json file in',
+                $exception->getPrevious()->getMessage()
+            );
         }
     }
 
@@ -884,13 +889,13 @@ JSON
             $this->fail('Expected exception to be thrown.');
         } catch (RuntimeException $exception) {
             $this->assertSame(
-                'Could not dump the autoload: Could not scan for classes inside "unknown" which does not appear to be a file nor a folder',
+                'Could not dump the autoloader.',
                 $exception->getMessage()
             );
             $this->assertSame(0, $exception->getCode());
             $this->assertNotNull($exception->getPrevious());
 
-            $this->assertSame(
+            $this->assertStringContainsString(
                 'Could not scan for classes inside "unknown" which does not appear to be a file nor a folder',
                 $exception->getPrevious()->getMessage()
             );

--- a/tests/Composer/ComposerOrchestratorTest.php
+++ b/tests/Composer/ComposerOrchestratorTest.php
@@ -110,9 +110,16 @@ PHP
 
             $this->fail('Expected exception to be thrown.');
         } catch (RuntimeException $exception) {
-            $this->assertStringStartsWith(
-                'Could not dump the autoload: "./composer.json" does not contain valid JSON',
+            $this->assertSame(
+                'Could not dump the autoloader.',
                 $exception->getMessage()
+            );
+            $this->assertSame(0, $exception->getCode());
+            $this->assertNotNull($exception->getPrevious());
+
+            $this->assertStringContainsString(
+                '"./composer.json" does not contain valid JSON',
+                $exception->getPrevious()->getMessage()
             );
         }
     }
@@ -192,9 +199,16 @@ PHP
 
             $this->fail('Expected exception to be thrown.');
         } catch (RuntimeException $exception) {
-            $this->assertStringStartsWith(
-                'Could not dump the autoload: Composer could not find a composer.json file in',
+            $this->assertSame(
+                'Could not dump the autoloader.',
                 $exception->getMessage()
+            );
+            $this->assertSame(0, $exception->getCode());
+            $this->assertNotNull($exception->getPrevious());
+
+            $this->assertStringContainsString(
+                'Composer could not find a composer.json file in',
+                $exception->getPrevious()->getMessage()
             );
         }
     }

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -100,6 +100,8 @@ class CompileTest extends CommandTestCase
                 return parent::execute($input, $options);
             }
         };
+
+        remove(self::FIXTURES_DIR.'/dir010/index.phar');
     }
 
     /**

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -873,6 +873,9 @@ Box version 3.x-dev@151e40a
   'rand' => $rand,
 )
 ? Dumping the Composer autoloader
+    > '/usr/local/bin/composer' 'dump-autoload' '--classmap-authoritative' '--no-dev'
+Generating optimized autoload files (authoritative)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08Generated optimized autoload files (authoritative) containing 0 classes
+
 ? Removing the Composer dump artefacts
 ? No compression
 ? Signing using a private key
@@ -892,6 +895,12 @@ No warning found.
 OUTPUT;
 
         $actual = $this->normalizeDisplay($this->commandTester->getDisplay(true));
+
+        $actual = preg_replace(
+            '/(\/.*?composer)/',
+            '/usr/local/bin/composer',
+            $actual
+        );
 
         $this->assertSame($expected, $actual);
     }
@@ -979,6 +988,9 @@ Box version 3.x-dev@151e40a
   'rand' => $rand,
 )
 ? Dumping the Composer autoloader
+    > '/usr/local/bin/composer' 'dump-autoload' '--classmap-authoritative' '--no-dev' '-v'
+Generating optimized autoload files (authoritative)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08Generated optimized autoload files (authoritative) containing 0 classes
+
 ? Removing the Composer dump artefacts
 ? No compression
 ? Signing using a private key

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -1014,7 +1014,14 @@ OUTPUT;
             (new PhpExecutableFinder())->find(),
             $expected
         );
+
         $actual = $this->normalizeDisplay($this->commandTester->getDisplay(true));
+
+        $actual = preg_replace(
+            '/(\/.*?composer)/',
+            '/usr/local/bin/composer',
+            $actual
+        );
 
         $this->assertSame($expected, $actual);
     }


### PR DESCRIPTION
Closes #398

- Fix how the Symfony environment variables are dumped (switch to `composer dump-env`)
- Use the user Composer executable instead of shipping one within Box