### PR TITLE
Fetch the xdebug version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@
 /fixtures/php-settings-checker/*
 !/fixtures/php-settings-checker/index.php
 !/fixtures/php-settings-checker/output-*
-fixtures/php-settings-checker/output-xdebug-enabled
+/fixtures/php-settings-checker/output-xdebug-enabled
+!/fixtures/php-settings-checker/create-expected-output
 /.phpunit*
 /.requirement-checker/
 /requirement-checker/bin/*

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 /fixtures/php-settings-checker/*
 !/fixtures/php-settings-checker/index.php
 !/fixtures/php-settings-checker/output-*
+fixtures/php-settings-checker/output-xdebug-enabled
 /.phpunit*
 /.requirement-checker/
 /requirement-checker/bin/*

--- a/Makefile
+++ b/Makefile
@@ -203,9 +203,7 @@ else
 endif
 .PHONY: e2e_php_settings_checker
 e2e_php_settings_checker: ## Runs the end-to-end tests for the PHP settings handler
-e2e_php_settings_checker: vendor box
-	./.docker/build
-
+e2e_php_settings_checker: docker-images fixtures/php-settings-checker/output-xdebug-enabled vendor box
 	# No restart needed
 	$(DOCKER) -v "$$PWD":/opt/box box_php72 \
 		php -dphar.readonly=0 -dmemory_limit=-1 \
@@ -383,3 +381,11 @@ box: bin src res vendor box.json.dist scoper.inc.php .requirement-checker
 
 requirement-checker/bin/check-requirements.phar: requirement-checker/src requirement-checker/bin/check-requirements.php requirement-checker/box.json.dist requirement-checker/vendor
 	bin/box compile --working-dir requirement-checker
+
+.PHONY: docker-images
+docker-images:
+	./.docker/build
+
+fixtures/php-settings-checker/output-xdebug-enabled: fixtures/php-settings-checker/output-xdebug-enabled.tpl docker-images
+	./fixtures/php-settings-checker/create-expected-output
+	touch $@

--- a/TODO
+++ b/TODO
@@ -1,5 +1,3 @@
-Add OS version info in metadata like done in Composer
-Check for the xdebug version in the expected output when testing for the php settings e2e tests
 Check the TODOs in the code
 Fix the error handler change occurring when compiling a PHAR
 Make dumped requirement checker prefix deterministic on a version basis

--- a/fixtures/php-settings-checker/create-expected-output
+++ b/fixtures/php-settings-checker/create-expected-output
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -Eeuox pipefail
+
+readonly OS=$(uname);
+readonly XDEBUG_VERSION=$(docker run -i --rm -w /opt/box box_php72_xdebug php -r "echo phpversion('xdebug');");
+readonly CURRENT_DIR=$(dirname $0);
+readonly TEMPLATE_FILE="${CURRENT_DIR}/output-xdebug-enabled.tpl";
+readonly DUMPED_FILE="${CURRENT_DIR}/output-xdebug-enabled";
+
+sed "s/__XDEBUG_VERSION__/${XDEBUG_VERSION}/g" ${TEMPLATE_FILE} > ${DUMPED_FILE};

--- a/fixtures/php-settings-checker/output-xdebug-enabled.tpl
+++ b/fixtures/php-settings-checker/output-xdebug-enabled.tpl
@@ -1,7 +1,7 @@
 [debug] Checking BOX_ALLOW_XDEBUG
 [debug] phar.readonly is disabled
-[debug] The xdebug extension is loaded (2.7.2)
-[debug] Process restarting (BOX_ALLOW_XDEBUG=internal|2.7.2|1|*|*)
+[debug] The xdebug extension is loaded (__XDEBUG_VERSION__)
+[debug] Process restarting (BOX_ALLOW_XDEBUG=internal|__XDEBUG_VERSION__|1|*|*)
 [debug] Running '/usr/local/bin/php' '-n' '-c' '/tmp-file' 'bin/box' 'compile' '--working-dir=fixtures/php-settings-checker' '-vvv' '--no-ansi'
 [debug] Current memory limit: "-1"
 [debug] Checking BOX_ALLOW_XDEBUG


### PR DESCRIPTION
The current PHP settings tests are a bit too flimsy since the xdebug version is explicitly expected in the output and that version may change.

This PR creates a new small bash script to fetch the xdebug version first and adjust the expected result accordingly.