### PR TITLE
Make the requirement checker dump deterministic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ compile: box
 .PHONY: dump-requirement-checker
 dump-requirement-checker:## Dumps the requirement checker
 dump-requirement-checker:
-	rm rf .requirement-checker || true
+	rm -rf .requirement-checker || true
 	$(MAKE) .requirement-checker
 
 
@@ -381,5 +381,6 @@ box: bin src res vendor box.json.dist scoper.inc.php .requirement-checker
 
 	touch $@
 
-requirement-checker/bin/check-requirements.phar: requirement-checker/src requirement-checker/bin/check-requirements.php requirement-checker/box.json.dist requirement-checker/vendor
+requirement-checker/bin/check-requirements.phar: requirement-checker/src requirement-checker/bin/check-requirements.php requirement-checker/box.json.dist requirement-checker/scoper.inc.php requirement-checker/vendor
 	bin/box compile --working-dir requirement-checker
+	touch $@

--- a/TODO
+++ b/TODO
@@ -2,4 +2,3 @@ Add OS version info in metadata like done in Composer
 Check for the xdebug version in the expected output when testing for the php settings e2e tests
 Check the TODOs in the code
 Fix the error handler change occurring when compiling a PHAR
-Make dumped requirement checker prefix deterministic on a version basis

--- a/requirement-checker/scoper.inc.php
+++ b/requirement-checker/scoper.inc.php
@@ -12,7 +12,30 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
+function get_prefix(): string
+{
+    $lastReleaseEndpoint = shell_exec(<<<'BASH'
+curl -s https://api.github.com/repos/humbug/box/releases/latest \
+  | grep "browser_download_url.*box.phar" \
+  | cut -d '"' -f 4
+BASH
+    );
+
+    if (1 !== preg_match('/download\/(?<version>.*?)\/box\.phar$/', $lastReleaseEndpoint, $matches)) {
+        throw new \RuntimeException(sprintf(
+            'Could not retrieve the last release endpoint. Last URL download link found: "%s"',
+            $lastReleaseEndpoint
+        ));
+    }
+
+    $lastRelease = $matches['version'];
+
+    return 'HumbugBox'.str_replace('.', '', $lastRelease);
+}
+
 return [
+    'prefix' => get_prefix(),
+
     'whitelist-global-classes' => false,
     'whitelist-global-functions' => false,
     'whitelist' => [


### PR DESCRIPTION
The requirement checker needs to be dumped whenever Box itself or the requirement checker changes. However as of now, the prefix used is random causing the git status to be constantly polluted by a newly dumped requirement checker.

In this PR, the prefix is constant but defined by the last release version which will fix the problem described above whilst ensuring each Box release will have a different requirement checker shipped.