### PR TITLE
Fix the change of error handler

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,3 +1,2 @@
 Check the TODOs in the code
-Fix the error handler change occurring when compiling a PHAR
 Make dumped requirement checker prefix deterministic on a version basis

--- a/src/Box.php
+++ b/src/Box.php
@@ -393,7 +393,9 @@ final class Box implements Countable
             // Keep the fully qualified call here since this function may be executed without the right autoloading
             // mechanism
             \KevinGH\Box\register_aliases();
-            \KevinGH\Box\register_error_handler();
+            if (true === \KevinGH\Box\is_parallel_processing_enabled()) {
+                \KevinGH\Box\register_error_handler();
+            }
 
             $contents = file_contents($file);
 


### PR DESCRIPTION
When Box is not compiling by using `amphp/parallel`, the current error handler should not be changed.