### PR TITLE
Simplify PhpSettings checker

### DIFF
--- a/fixtures/php-settings-checker/output-all-clear
+++ b/fixtures/php-settings-checker/output-all-clear
@@ -1,4 +1,4 @@
 [debug] Checking BOX_ALLOW_XDEBUG
+[debug] Current memory limit: "-1"
 [debug] phar.readonly is disabled
 [debug] The xdebug extension is not loaded
-[debug] Current memory limit: "-1"

--- a/fixtures/php-settings-checker/output-all-clear
+++ b/fixtures/php-settings-checker/output-all-clear
@@ -1,4 +1,4 @@
-[debug] Checking BOX_ALLOW_XDEBUG
 [debug] Current memory limit: "-1"
+[debug] Checking BOX_ALLOW_XDEBUG
 [debug] phar.readonly is disabled
 [debug] The xdebug extension is not loaded

--- a/fixtures/php-settings-checker/output-min-memory-limit
+++ b/fixtures/php-settings-checker/output-min-memory-limit
@@ -1,4 +1,4 @@
 [debug] Checking BOX_ALLOW_XDEBUG
+[debug] Changed the memory limit from "124MB" to "512M"
 [debug] phar.readonly is disabled
 [debug] The xdebug extension is not loaded
-[debug] Changed the memory limit from "124MB" to "512M"

--- a/fixtures/php-settings-checker/output-min-memory-limit
+++ b/fixtures/php-settings-checker/output-min-memory-limit
@@ -1,4 +1,4 @@
-[debug] Checking BOX_ALLOW_XDEBUG
 [debug] Changed the memory limit from "124MB" to "512M"
+[debug] Checking BOX_ALLOW_XDEBUG
 [debug] phar.readonly is disabled
 [debug] The xdebug extension is not loaded

--- a/fixtures/php-settings-checker/output-pharreadonly-enabled
+++ b/fixtures/php-settings-checker/output-pharreadonly-enabled
@@ -1,11 +1,10 @@
 [debug] Checking BOX_ALLOW_XDEBUG
+[debug] Current memory limit: "-1"
 [debug] phar.readonly is enabled
 [debug] The xdebug extension is not loaded
 [debug] Process restarting (BOX_ALLOW_XDEBUG=internal||1|*|*)
 [debug] Running '/usr/local/bin/php' '-n' '-c' '/tmp-file' 'bin/box' 'compile' '--working-dir=fixtures/php-settings-checker' '-vvv' '--no-ansi'
 [debug] Configured `phar.readonly=0`
-[debug] Current memory limit: "-1"
 [debug] Checking BOX_ALLOW_XDEBUG
 [debug] Restarted (100 ms). The xdebug extension is not loaded
-[debug] Current memory limit: "-1"
 [debug] Restarted process exited 0

--- a/fixtures/php-settings-checker/output-pharreadonly-enabled
+++ b/fixtures/php-settings-checker/output-pharreadonly-enabled
@@ -1,10 +1,11 @@
-[debug] Checking BOX_ALLOW_XDEBUG
 [debug] Current memory limit: "-1"
+[debug] Checking BOX_ALLOW_XDEBUG
 [debug] phar.readonly is enabled
 [debug] The xdebug extension is not loaded
 [debug] Process restarting (BOX_ALLOW_XDEBUG=internal||1|*|*)
 [debug] Running '/usr/local/bin/php' '-n' '-c' '/tmp-file' 'bin/box' 'compile' '--working-dir=fixtures/php-settings-checker' '-vvv' '--no-ansi'
 [debug] Configured `phar.readonly=0`
+[debug] Current memory limit: "-1"
 [debug] Checking BOX_ALLOW_XDEBUG
 [debug] Restarted (100 ms). The xdebug extension is not loaded
 [debug] Restarted process exited 0

--- a/fixtures/php-settings-checker/output-set-memory-limit
+++ b/fixtures/php-settings-checker/output-set-memory-limit
@@ -1,4 +1,4 @@
-[debug] Checking BOX_ALLOW_XDEBUG
 [debug] Changed the memory limit from "1GB" to BOX_MEMORY_LIMIT="64MB"
+[debug] Checking BOX_ALLOW_XDEBUG
 [debug] phar.readonly is disabled
 [debug] The xdebug extension is not loaded

--- a/fixtures/php-settings-checker/output-set-memory-limit
+++ b/fixtures/php-settings-checker/output-set-memory-limit
@@ -1,4 +1,4 @@
 [debug] Checking BOX_ALLOW_XDEBUG
+[debug] Changed the memory limit from "1GB" to BOX_MEMORY_LIMIT="64MB"
 [debug] phar.readonly is disabled
 [debug] The xdebug extension is not loaded
-[debug] Changed the memory limit from "1GB" to BOX_MEMORY_LIMIT="64MB"

--- a/fixtures/php-settings-checker/output-xdebug-enabled.tpl
+++ b/fixtures/php-settings-checker/output-xdebug-enabled.tpl
@@ -1,10 +1,9 @@
 [debug] Checking BOX_ALLOW_XDEBUG
+[debug] Current memory limit: "-1"
 [debug] phar.readonly is disabled
 [debug] The xdebug extension is loaded (__XDEBUG_VERSION__)
 [debug] Process restarting (BOX_ALLOW_XDEBUG=internal|__XDEBUG_VERSION__|1|*|*)
 [debug] Running '/usr/local/bin/php' '-n' '-c' '/tmp-file' 'bin/box' 'compile' '--working-dir=fixtures/php-settings-checker' '-vvv' '--no-ansi'
-[debug] Current memory limit: "-1"
 [debug] Checking BOX_ALLOW_XDEBUG
 [debug] Restarted (100 ms). The xdebug extension is not loaded
-[debug] Current memory limit: "-1"
 [debug] Restarted process exited 0

--- a/fixtures/php-settings-checker/output-xdebug-enabled.tpl
+++ b/fixtures/php-settings-checker/output-xdebug-enabled.tpl
@@ -1,9 +1,10 @@
-[debug] Checking BOX_ALLOW_XDEBUG
 [debug] Current memory limit: "-1"
+[debug] Checking BOX_ALLOW_XDEBUG
 [debug] phar.readonly is disabled
 [debug] The xdebug extension is loaded (__XDEBUG_VERSION__)
 [debug] Process restarting (BOX_ALLOW_XDEBUG=internal|__XDEBUG_VERSION__|1|*|*)
 [debug] Running '/usr/local/bin/php' '-n' '-c' '/tmp-file' 'bin/box' 'compile' '--working-dir=fixtures/php-settings-checker' '-vvv' '--no-ansi'
+[debug] Current memory limit: "-1"
 [debug] Checking BOX_ALLOW_XDEBUG
 [debug] Restarted (100 ms). The xdebug extension is not loaded
 [debug] Restarted process exited 0

--- a/src/Console/Php/PhpSettingsHandler.php
+++ b/src/Console/Php/PhpSettingsHandler.php
@@ -52,10 +52,18 @@ final class PhpSettingsHandler extends XdebugHandler
     /**
      * {@inheritdoc}
      */
-    protected function requiresRestart($isLoaded): bool
+    public function check()
     {
         $this->bumpMemoryLimit();
 
+        return parent::check();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function requiresRestart($isLoaded): bool
+    {
         if ($this->pharReadonly) {
             $this->logger->debug('phar.readonly is enabled');
 

--- a/tests/Console/Command/CompileTest.php
+++ b/tests/Console/Command/CompileTest.php
@@ -1085,9 +1085,9 @@ JSON
         );
 
         $expected = <<<OUTPUT
+$memoryLog
 [debug] Checking BOX_ALLOW_XDEBUG
 $xdebugLog
-$memoryLog
 [debug] Disabled parallel processing
 
     ____


### PR DESCRIPTION
- No longer depends on the internal `Process::setEnv()` method
- Checks the memory limit only once (in the main process which is picked up by the sub-processes)