### PR TITLE
Bump version requirement for json-schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "composer/xdebug-handler": "^1.3.2",
         "hoa/compiler": "^3.17",
         "humbug/php-scoper": "~0.12",
-        "justinrainbow/json-schema": "^5.2",
+        "justinrainbow/json-schema": "^5.2.9",
         "nikic/iter": "^2.0",
         "nikic/php-parser": "^4.2",
         "ocramius/package-versions": "^1.4",


### PR DESCRIPTION
Fixes #439

(This is not yet a released version, so builds will naturally fail.)