### PR TITLE
chore: remove `bottle :unneeded` to prevent deprecation warning

### DIFF
--- a/.github/tap-release.yml
+++ b/.github/tap-release.yml
@@ -8,8 +8,6 @@ template: >
         sha256 "$STABLE_ASSET_SHA256"
         version "$STABLE_VERSION"
 
-        bottle :unneeded
-
         depends_on "php" if MacOS.version <= :el_capitan
 
         def install


### PR DESCRIPTION
This removes the `bottle :unneeded` stanza for future Tap releases (related to https://github.com/box-project/homebrew-box/pull/7), otherwise it will just be re-added when a new release is created.