### PR TITLE
ci: Fix running tests with PHAR readonly or writeable

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
     unit-tests:
         runs-on: ubuntu-latest
-        name: Unit-Tests (PHP ${{ matrix.php.version }}, ${{ matrix.php.dependency }}, ${{ matrix.tools }})
+        name: Unit-Tests (PHP ${{ matrix.php.version }}, ${{ matrix.php.dependency }}, ${{ matrix.tools }}) - PHAR ${{ matrix.phar-readonly && 'readonly' || 'writeable' }}"
         strategy:
             fail-fast: false
             matrix:
@@ -28,6 +28,7 @@ jobs:
                 tools:
                     # TODO: add more composer versions
                     - composer
+                phar-readonly: [ true, false ]
         steps:
             -   name: Checkout
                 uses: actions/checkout@v3
@@ -38,7 +39,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php.version }}
-                    ini-values: phar.readonly=0, display_errors=On, error_reporting=-1
+                    ini-values: ${{ matrix.phar-readonly && 'phar.readonly=1' || 'phar.readonly=0' }}, display_errors=On, error_reporting=-1
                     tools: ${{ matrix.tools }}
                     coverage: none
                     extensions: ctype, iconv, xml
@@ -52,8 +53,7 @@ jobs:
             -   name: Ensure that the make target is up to date
                 run: make vendor_install
 
-            -   run: make phpunit_phar_readonly
-            -   run: make phpunit_phar_writeable
+            -   run: make phpunit
 
     infection:
         runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,10 @@ phpunit_phar_readonly: $(PHPUNIT_BIN) $(PHPUNIT_TEST_SRC)
 phpunit_phar_writeable: $(PHPUNIT_BIN) $(PHPUNIT_TEST_SRC)
 	php -dphar.readonly=1 $(PHPUNIT) --testsuite=Tests --colors=always
 
+.PHONY: phpunit
+phpunit: $(PHPUNIT_BIN) $(PHPUNIT_TEST_SRC)
+	$(PHPUNIT) --testsuite=Tests --colors=always
+
 .PHONY: phpunit_coverage_html
 phpunit_coverage_html:      ## Runs PHPUnit with code coverage with HTML report
 phpunit_coverage_html: $(PHPUNIT_BIN) dist $(PHPUNIT_TEST_SRC) vendor


### PR DESCRIPTION
The make commands `make phpunit_phar_readonly` and `make phpunit_phar_writeable` are helpful but not good enough for the CI. Indeed the tests executed in different processes are not inheriting the ini values set at runtime. So doing `php -dphar.readonly=0` will not work for the tests with `@runInSeparateProcesses`.