### PR TITLE
refactor: Remove unnecessary dump-autoload condition

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -150,13 +150,11 @@ final class Box implements Countable
                 );
             }
 
-            if (null !== $dumpAutoload) {
-                $dumpAutoload(
-                    $this->scoper->getSymbolsRegistry(),
-                    $this->scoper->getPrefix(),
-                    $this->scoper->getExcludedFilePaths(),
-                );
-            }
+            $dumpAutoload(
+                $this->scoper->getSymbolsRegistry(),
+                $this->scoper->getPrefix(),
+                $this->scoper->getExcludedFilePaths(),
+            );
 
             chdir($cwd);
 


### PR DESCRIPTION
We have a noop fallback hence `$dumpAutoload` can never be `null` at that point.