### PR TITLE
fix: Ensure we restore the working directory upon failure

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -158,8 +158,6 @@ final class Box implements Countable
                 );
             }
 
-            chdir($cwd);
-
             $unknownFiles = Finder::create()
                 ->files()
                 ->in($tmp)
@@ -178,6 +176,8 @@ final class Box implements Countable
             $this->phar->buildFromIterator(new ArrayIterator($files), $tmp);
         } finally {
             FS::remove($tmp);
+            // Must happen _after_ the remove as the latter has higher priority.
+            chdir($cwd);
         }
 
         $this->buffering = false;


### PR DESCRIPTION
It is part of a "cleanup" step, so moving it out of the `try` removes the confusion that it may be necessary as a part to add the files to the PHAR.