### PR TITLE
perf: Do not sort files collected by the Finder

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -159,8 +159,7 @@ final class Box implements Countable
             $unknownFiles = Finder::create()
                 ->files()
                 ->in($tmp)
-                ->notPath(array_keys($files))
-                ->sortByName();
+                ->notPath(array_keys($files));
 
             $files = [...$files, ...$unknownFiles];
 


### PR DESCRIPTION
We sort them afterwards already hence this is unnecessary.