### PR TITLE
test: Fix the normalization of references of the VarDumper

### DIFF
--- a/tests/Console/DisplayNormalizer.php
+++ b/tests/Console/DisplayNormalizer.php
@@ -52,7 +52,7 @@ final class DisplayNormalizer
     public static function createVarDumperObjectReferenceNormalizer(): callable
     {
         return static fn ($output) => preg_replace(
-            '/ \{#\d{3,}/',
+            '/ \{#\d+/',
             ' {#140',
             $output,
         );

--- a/tests/Console/DisplayNormalizerTest.php
+++ b/tests/Console/DisplayNormalizerTest.php
@@ -83,4 +83,72 @@ final class DisplayNormalizerTest extends TestCase
                 EOF,
         ];
     }
+
+    #[DataProvider('varDumperObjectReferenceProvider')]
+    public static function test_it_can_normalize_an_object_reference_from_the_var_dumper(
+        string $value,
+        ?string $expected,
+    ): void {
+        $expected ??= $value;
+
+        $actual = DisplayNormalizer::createVarDumperObjectReferenceNormalizer()($value);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function varDumperObjectReferenceProvider(): iterable
+    {
+        $unchanged = null;
+
+        yield '3 digits' => [
+            <<<'EOF'
+                Humbug\\PhpScoper\\Symbol\\SymbolsRegistry {#500
+                  -recordedFunctions: []
+                  -recordedClasses: []
+                }
+
+                EOF,
+            <<<'EOF'
+                Humbug\\PhpScoper\\Symbol\\SymbolsRegistry {#140
+                  -recordedFunctions: []
+                  -recordedClasses: []
+                }
+
+                EOF,
+        ];
+
+        yield '2 digits' => [
+            <<<'EOF'
+                Humbug\\PhpScoper\\Symbol\\SymbolsRegistry {#50
+                  -recordedFunctions: []
+                  -recordedClasses: []
+                }
+
+                EOF,
+            <<<'EOF'
+                Humbug\\PhpScoper\\Symbol\\SymbolsRegistry {#140
+                  -recordedFunctions: []
+                  -recordedClasses: []
+                }
+
+                EOF,
+        ];
+
+        yield '1 digit' => [
+            <<<'EOF'
+                Humbug\\PhpScoper\\Symbol\\SymbolsRegistry {#5
+                  -recordedFunctions: []
+                  -recordedClasses: []
+                }
+
+                EOF,
+            <<<'EOF'
+                Humbug\\PhpScoper\\Symbol\\SymbolsRegistry {#140
+                  -recordedFunctions: []
+                  -recordedClasses: []
+                }
+
+                EOF,
+        ];
+    }
 }


### PR DESCRIPTION
This should fix this scenario which was happening in the CI:

```
There was 1 failure:

1) KevinGH\Box\Console\Command\ProcessCommandTest::test_it_processes_the_file_relative_to_the_config_base_path
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 Symbols Registry:

 """
-Humbug\PhpScoper\Symbol\SymbolsRegistry {#140
+Humbug\PhpScoper\Symbol\SymbolsRegistry {#33
   -recordedFunctions: []
   -recordedClasses: []
 }
```