### PR TITLE
perf: Improve performance of Box::collectRemainingFiles()

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -48,9 +48,8 @@ use function dirname;
 use function extension_loaded;
 use function file_exists;
 use function getcwd;
+use function in_array;
 use function is_object;
-use function iter\fromPairs;
-use function iter\map;
 use function openssl_pkey_export;
 use function openssl_pkey_get_details;
 use function openssl_pkey_get_private;
@@ -222,18 +221,15 @@ final class Box implements Countable
         string $tmp,
         array $bufferedFileNames,
     ): iterable {
-        return fromPairs(
-            map(
-                static fn (SplFileInfo $fileInfo) => [
-                    $fileInfo->getRelativePathname(),
-                    $fileInfo->getPathname(),
-                ],
-                Finder::create()
-                    ->files()
-                    ->in($tmp)
-                    ->notPath($bufferedFileNames),
-            ),
-        );
+        $finder = Finder::create()->files()->in($tmp);
+
+        foreach ($finder as $fileInfo) {
+            if (in_array($fileInfo->getRelativePathname(), $bufferedFileNames, true)) {
+                continue;
+            }
+
+            yield $fileInfo->getRelativePathname() => $fileInfo->getPathname();
+        }
     }
 
     /**


### PR DESCRIPTION
The `->notPath()` filter of Symfony Finder is either accepting a “literal path” or a regular expression and converts each literal path to a regular expression and then filters the file stream by applying each regex individually. This leads to O(bufferedFileNames^2) calls to `preg_match()`, well over 20 million for PHPStan.

Fix this by performing a simple `in_array()` check on the buffered files. This brings down the time to compile PHPStan from 2:35 to 0:25 on my machine.

I have verified that the resulting PHPStan Phar hash is identical before and after this change.

Fixes box-project/box#1551.

-----------------

Tideways Comparison showing the improvement: https://app.tideways.io/share/trace/55089586-d71b-4fe5-a00a-08482ad2df06/compare/3abe5b8b-a960-4c0a-9c43-437a3dc23630/callgraph (link valid for 1 month, screenshot for posterity).

<img width="2066" height="1005" alt="scrot_2025_10_31_11_52_43" src="https://github.com/user-attachments/assets/032b5294-227e-42af-bdea-4983b7954646" />
