### PR TITLE
Avoid errors in PHP 8.5

### DIFF
--- a/src/RequirementChecker/RequirementsBuilder.php
+++ b/src/RequirementChecker/RequirementsBuilder.php
@@ -58,6 +58,9 @@ final class RequirementsBuilder
 
     public function addRequiredExtension(Extension $extension, ?string $source): void
     {
+        if (!$source) {
+            $source = '';
+        }
         $this->requiredExtensions[$extension->name][] = $source;
         $this->allExtensions[$extension->name][$source] = [$source, RequirementType::EXTENSION];
     }


### PR DESCRIPTION
In my builds on PHP 8.5 I am getting this error:

```
31.24 
31.24     ____
31.24    / __ )____  _  __
31.24   / __  / __ \| |/_/
31.24  / /_/ / /_/ />  <
31.24 /_____/\____/_/|_|
31.24 
31.24 
31.24 Box version 4.6.10@6dc6a13
31.24 
31.25  // Loading the configuration file "/usr/src/myapp/box.json".                   
31.25 
31.31 🔨  Building the PHAR "/usr/src/myapp/runner.phar"
31.31 
31.31 ? Removing the existing PHAR "/usr/src/myapp/runner.phar"
31.31 ? Checking Composer compatibility
31.42     > Supported version detected
31.42 ? No compactor to register
31.42 ? Adding main file: /usr/src/myapp/runner.php
31.42 ? Adding requirements checker
31.42 
31.43 In RequirementsBuilder.php line 62:
31.43                                                                             
31.43   Using null as an array offset is deprecated, use an empty string instead  
```

This simple fix avoids it for me