### PR TITLE
Update documentation links for installation and configuration

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -26,7 +26,7 @@ great things:
 
 ## Docs
 
-Go do the [documentation](installation.md#installation).
+Find out more about [installation](installation.md#installation) and [configuration](configuration.md#configuration).
 
 
 ## Usage


### PR DESCRIPTION
I noticed what might have been a typo ("do" instead of "to") and opted to replace the phrasing with additional context.